### PR TITLE
Enforce no lint warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@ This repository uses TypeScript and Lit to build web components, a browser exten
 
 - Keep the codebase accessible and mobile friendly. Follow WCAG 2.1 AA guidelines and prefer responsive, mobile‑first layout techniques.
 - Use the `webcomponents` package as the source of truth for the RSVP player component. Tests live under `webcomponents/src` and must pass via `npm test`.
-- Run `npm run lint` before committing. The linter checks TypeScript code with ESLint (including `lit-a11y`) and CSS with Stylelint.
-- New lint rules using SonarJS and Unicorn enforce software craftsmanship. Fix or disable warnings to keep code clean, DRY, and easy to maintain.
+- Run `npm run lint` before committing. The linter checks TypeScript code with ESLint (including `lit-a11y`) and CSS with Stylelint. **Warnings are treated as errors** so the build fails if any are present.
+- New lint rules using SonarJS and Unicorn enforce software craftsmanship. Fix or disable warnings to keep code clean, DRY, and easy to maintain. Never commit with remaining warnings.
 - Practice the Boy Scout Rule: whenever you touch code, run the linters and clean up any warnings you encounter.
 - Follow Uncle Bob's Clean Code and Architecture guidelines. Keep modules small, respect SRP, and avoid needless repetition.
 - When adding new features, include unit tests and ensure existing tests keep ≥90% coverage.

--- a/webcomponents/package.json
+++ b/webcomponents/package.json
@@ -8,8 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "node --experimental-vm-modules ../node_modules/jest/bin/jest.js",
-    "lint:js": "eslint src/**/*.{ts,js}",
-    "lint:css": "stylelint src/**/*.css",
+    "lint:js": "eslint --max-warnings 0 src/**/*.{ts,js}",
+    "lint:css": "stylelint src/**/*.css --max-warnings 0",
     "lint": "npm run lint:js && npm run lint:css"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- clarify agent instructions to treat warnings as errors
- fail lint on warnings using `--max-warnings 0`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e77de2e3c8331a21b578d402f77ff