### PR TITLE
Fix mobile fullscreen layout

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>RSVP Player Demo</title>
 </head>
-<body>
+<body style="margin:0;">
   <h1>RSVP Player Demo</h1>
   <rsvp-player text="This is a demo of the RSVP player rendered from a separate webapp."></rsvp-player>
   <script type="module" src="/src/main.ts"></script>

--- a/webcomponents/e2e/mobile-layout.spec.ts
+++ b/webcomponents/e2e/mobile-layout.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const filePath = resolve(__dirname, '../dist/index.html');
+
+test('rsvp-player fills viewport on mobile', async ({ page }) => {
+  await page.goto('file://' + filePath);
+  const box = await page.locator('rsvp-player').boundingBox();
+  expect(box?.width).toBeCloseTo(375, 1);
+  expect(box?.height).toBeCloseTo(667, 1);
+});

--- a/webcomponents/index.html
+++ b/webcomponents/index.html
@@ -6,7 +6,7 @@
   <title>Speed Reader</title>
   <link href="/src/styles.css" rel="stylesheet" />
 </head>
-<body>
+<body style="margin:0;">
   <rsvp-player text="This is a demo of the RSVP player. Use the controls or keyboard to play, pause, and adjust speed."></rsvp-player>
   <script type="module" src="/src/main.ts"></script>
 </body>

--- a/webcomponents/jest.config.cjs
+++ b/webcomponents/jest.config.cjs
@@ -17,5 +17,6 @@ module.exports = {
       tsconfig: '<rootDir>/tsconfig.json'
     }
   },
+  testPathIgnorePatterns: ['<rootDir>/e2e/'],
   rootDir: '.'
 };

--- a/webcomponents/package.json
+++ b/webcomponents/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "node --experimental-vm-modules ../node_modules/jest/bin/jest.js",
+    "test:e2e": "playwright test",
     "lint:js": "eslint --max-warnings 0 src/**/*.{ts,js}",
     "lint:css": "stylelint src/**/*.css --max-warnings 0",
     "lint": "npm run lint:js && npm run lint:css"
@@ -35,6 +36,7 @@
     "tailwindcss": "^3.0.0",
     "ts-jest": "^29.0.0",
     "typescript": "^4.7.0",
-    "vite": "^4.0.0"
+    "vite": "^4.0.0",
+    "@playwright/test": "^1.42.1"
   }
 }

--- a/webcomponents/playwright.config.ts
+++ b/webcomponents/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test';
+import { join } from 'path';
+
+export default defineConfig({
+  testDir: join(__dirname, 'e2e'),
+  use: {
+    viewport: { width: 375, height: 667 },
+    launchOptions: {
+      args: ['--allow-file-access-from-files']
+    }
+  },
+});

--- a/webcomponents/src/components/rsvp-player.mobile.test.ts
+++ b/webcomponents/src/components/rsvp-player.mobile.test.ts
@@ -1,0 +1,11 @@
+import '@testing-library/jest-dom';
+import { RsvpPlayer } from './rsvp-player';
+
+describe('RsvpPlayer mobile layout', () => {
+  it('includes mobile fullscreen styles', () => {
+    const css = Array.isArray(RsvpPlayer.styles) ? RsvpPlayer.styles.map(s => s.cssText).join('') : RsvpPlayer.styles.cssText;
+    expect(css).toMatch(/@media\s*\(max-width: 600px\)/);
+    expect(css).toMatch(/min-height:\s*100dvh/);
+    expect(css).toMatch(/width:\s*100vw/);
+  });
+});

--- a/webcomponents/src/components/rsvp-player.ts
+++ b/webcomponents/src/components/rsvp-player.ts
@@ -51,6 +51,15 @@ export class RsvpPlayer extends LitElement {
       flex-direction: column;
       justify-content: center; /* Center word vertically */
       position: relative; /* Needed for settings pane positioning */
+      width: 100%;
+    }
+
+    @media (max-width: 600px) {
+      :host {
+        min-height: 100dvh;
+        width: 100vw;
+        margin: 0;
+      }
     }
 
     .word {


### PR DESCRIPTION
## Summary
- ensure player fills the viewport on small screens
- remove body margins in demo pages
- check mobile styles in Jest
- set up Playwright and add an e2e test

## Testing
- `npm run lint`
- `npm test`
- `npx playwright test webcomponents/e2e/mobile-layout.spec.ts --browser=chromium` *(fails: page not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_685e799e45608331822ddfaecd1e806b