### PR TITLE
Expand WPM range to 100-800

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Speed-Reader is a cross-platform reading tool that presents text one word at a t
 ## 2. Core User Experience
 - **Controls:**
   - Play/Pause: Spacebar or button
-  - Speed Up/Down: Arrow Up/Down (200–350 wpm, default 300)
+  - Speed Up/Down: Arrow Up/Down (100–800 wpm, default 300)
   - Rewind: Arrow Left (rewind 5 words)
   - Fullscreen: F or button
   - Settings/Mode: Gear icon
@@ -20,7 +20,7 @@ Speed-Reader is a cross-platform reading tool that presents text one word at a t
 
 ## 3. Functional Requirements
 1. **Configurable Control** ([feature](features/configurable_control.feature))
-   - Adjustable WPM range (200–350, default 300). Comprehension drops above 300 wpm ([Di Nocera et al.](https://www.sciencedirect.com/science/article/pii/S0747563214007663), [Ricciardi et al.](https://www.researchgate.net/profile/Orlando-Ricciardi/publication/328925418_Rapid_serial_visual_presentation_Degradation_of_inferential_reading_comprehension_as_a_function_of_speed/links/5e5f7ec04585152ce8053ccd/Rapid-serial-visual-presentation-Degradation-of-inferential-reading-comprehension-as-a-function-of-speed.pdf)).
+   - Adjustable WPM range (100–800, default 300). Comprehension drops above 300 wpm ([Di Nocera et al.](https://www.sciencedirect.com/science/article/pii/S0747563214007663), [Ricciardi et al.](https://www.researchgate.net/profile/Orlando-Ricciardi/publication/328925418_Rapid_serial_visual_presentation_Degradation_of_inferential_reading_comprehension_as_a_function_of_speed/links/5e5f7ec04585152ce8053ccd/Rapid-serial-visual_presentation-Degradation-of-inferential-reading-comprehension-as-a-function-of-speed.pdf)). See [design decision](design/decisions/0001-wpm-range.md).
    - Dynamic speed control: Auto-adjust pacing based on comprehension quiz results.
 2. **Gradient-Guided Text** ([feature](features/gradient_guided_text.feature))
    - BeeLine-style color gradients for continuous text to guide eye movement ([WestEd BeeLine Study](https://www.rif.org/sites/default/files/documents/2019/10/24/Support_Materials/BeeLineWestEdStudyFinal.pdf)).
@@ -34,7 +34,7 @@ Speed-Reader is a cross-platform reading tool that presents text one word at a t
    - Gaze-based pausing and regression support if hardware is available ([Rayner & Pollatsek](https://www.mdpi.com/2226-471X/9/12/360)).
 
 ## 4. Non-Functional Requirements
-- **Performance:** <50 ms latency per word at 350 wpm
+- **Performance:** <50 ms latency per word at 800 wpm
 - **Cross-Platform:** Responsive web, browser extensions, offline PWA, future native apps
 - **Offline Support:** PWA must work offline (service worker, IndexedDB)
 - **Accessibility:** WCAG 2.1 AA, adjustable font/contrast, ARIA labels

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -6,6 +6,7 @@ This folder contains W3C-compliant design tokens for the Speed-Reader project. D
 - [Main Requirements & Design Guidelines](../README.md)
 - [Feature Specifications](../features/)
 - [Architecture Docs](../architecture/README.md)
+- [Design Decisions](decisions/)
 
 ## Token Files
 

--- a/docs/design/decisions/0001-wpm-range.md
+++ b/docs/design/decisions/0001-wpm-range.md
@@ -1,0 +1,9 @@
+# Decision: Expand WPM Range
+
+We reduced the minimum playback speed from 200 to 100 words per minute and increased
+the maximum from 350 to 800 wpm. This change supports users who require a slower
+starting point and those who wish to experiment with much faster speeds.
+
+Although studies show comprehension drops above 300 wpm, the wider range allows
+advanced readers and researchers to evaluate extreme speeds while keeping the
+default at 300 wpm.

--- a/docs/features/configurable_control.feature
+++ b/docs/features/configurable_control.feature
@@ -13,12 +13,12 @@ Feature: Configurable Control
   Scenario: Increasing speed
     Given the player is playing at 300 wpm
     When I press the "Arrow Up" key
-    Then the playback speed increases by a fixed increment within the range 200-350 wpm
+    Then the playback speed increases by a fixed increment within the range 100-800 wpm
 
   Scenario: Decreasing speed
     Given the player is playing at 300 wpm
     When I press the "Arrow Down" key
-    Then the playback speed decreases by a fixed increment within the range 200-350 wpm
+    Then the playback speed decreases by a fixed increment within the range 100-800 wpm
 
   Scenario: Rewinding words
     Given the player has advanced 10 words

--- a/webcomponents/src/components/rsvp-player.test.ts
+++ b/webcomponents/src/components/rsvp-player.test.ts
@@ -57,7 +57,7 @@ describe.skip('RsvpPlayer', () => {
     await el.updateComplete;
     const newWpm = el.wpm;
     expect(newWpm).toBeGreaterThan(initial);
-    expect(newWpm).toBeLessThanOrEqual(350);
+    expect(newWpm).toBeLessThanOrEqual(800);
     expect(display).toHaveTextContent(`${newWpm} WPM`);
   });
 
@@ -70,7 +70,7 @@ describe.skip('RsvpPlayer', () => {
     await el.updateComplete;
     const newWpm = el.wpm;
     expect(newWpm).toBeLessThan(initial);
-    expect(newWpm).toBeGreaterThanOrEqual(200);
+    expect(newWpm).toBeGreaterThanOrEqual(100);
     expect(display).toHaveTextContent(`${newWpm} WPM`);
   });
 

--- a/webcomponents/src/components/rsvp-player.ts
+++ b/webcomponents/src/components/rsvp-player.ts
@@ -32,8 +32,8 @@ export class RsvpPlayer extends LitElement {
   @state() private showSettingsPane: boolean = false;
 
   private timerId?: number;
-  private static readonly MIN_WPM = 200;
-  private static readonly MAX_WPM = 350;
+  private static readonly MIN_WPM = 100;
+  private static readonly MAX_WPM = 800;
   private static readonly STEP = 50;
   private static readonly REWIND_WORDS = 5;
   private static readonly FAST_FORWARD_WORDS = 5; // Added for fast forward functionality


### PR DESCRIPTION
## Summary
- widen playback speed range in `rsvp-player`
- update tests for new limits
- document new range in requirements and feature spec
- record design decision for adjusting WPM limits
- link design decision in docs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e7d039d048331b7d9c8cdadc67055