### PR TITLE
Fix settings panel on mobile

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Speed-Reader is a cross-platform reading tool that presents text one word at a t
 ## 2. Core User Experience
 - **Controls:**
   - Play/Pause: Spacebar or button
-  - Speed Up/Down: Arrow Up/Down (200–350 wpm, default 300)
+  - Speed Up/Down: Arrow Up/Down (100–800 wpm, default 300)
   - Rewind: Arrow Left (rewind 5 words)
   - Fullscreen: F or button
   - Settings/Mode: Gear icon
@@ -20,7 +20,7 @@ Speed-Reader is a cross-platform reading tool that presents text one word at a t
 
 ## 3. Functional Requirements
 1. **Configurable Control** ([feature](features/configurable_control.feature))
-   - Adjustable WPM range (200–350, default 300). Comprehension drops above 300 wpm ([Di Nocera et al.](https://www.sciencedirect.com/science/article/pii/S0747563214007663), [Ricciardi et al.](https://www.researchgate.net/profile/Orlando-Ricciardi/publication/328925418_Rapid_serial_visual_presentation_Degradation_of_inferential_reading_comprehension_as_a_function_of_speed/links/5e5f7ec04585152ce8053ccd/Rapid-serial-visual-presentation-Degradation-of-inferential-reading-comprehension-as-a-function-of-speed.pdf)).
+   - Adjustable WPM range (100–800, default 300). Comprehension drops above 300 wpm ([Di Nocera et al.](https://www.sciencedirect.com/science/article/pii/S0747563214007663), [Ricciardi et al.](https://www.researchgate.net/profile/Orlando-Ricciardi/publication/328925418_Rapid_serial_visual_presentation_Degradation_of_inferential_reading_comprehension_as_a_function_of_speed/links/5e5f7ec04585152ce8053ccd/Rapid-serial-visual_presentation-Degradation-of-inferential-reading-comprehension-as-a-function-of-speed.pdf)). See [design decision](design/decisions/0001-wpm-range.md).
    - Dynamic speed control: Auto-adjust pacing based on comprehension quiz results.
 2. **Gradient-Guided Text** ([feature](features/gradient_guided_text.feature))
    - BeeLine-style color gradients for continuous text to guide eye movement ([WestEd BeeLine Study](https://www.rif.org/sites/default/files/documents/2019/10/24/Support_Materials/BeeLineWestEdStudyFinal.pdf)).
@@ -34,7 +34,7 @@ Speed-Reader is a cross-platform reading tool that presents text one word at a t
    - Gaze-based pausing and regression support if hardware is available ([Rayner & Pollatsek](https://www.mdpi.com/2226-471X/9/12/360)).
 
 ## 4. Non-Functional Requirements
-- **Performance:** <50 ms latency per word at 350 wpm
+- **Performance:** <50 ms latency per word at 800 wpm
 - **Cross-Platform:** Responsive web, browser extensions, offline PWA, future native apps
 - **Offline Support:** PWA must work offline (service worker, IndexedDB)
 - **Accessibility:** WCAG 2.1 AA, adjustable font/contrast, ARIA labels

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -6,6 +6,7 @@ This folder contains W3C-compliant design tokens for the Speed-Reader project. D
 - [Main Requirements & Design Guidelines](../README.md)
 - [Feature Specifications](../features/)
 - [Architecture Docs](../architecture/README.md)
+- [Design Decisions](decisions/)
 
 ## Token Files
 

--- a/docs/design/decisions/0001-wpm-range.md
+++ b/docs/design/decisions/0001-wpm-range.md
@@ -1,0 +1,9 @@
+# Decision: Expand WPM Range
+
+We reduced the minimum playback speed from 200 to 100 words per minute and increased
+the maximum from 350 to 800 wpm. This change supports users who require a slower
+starting point and those who wish to experiment with much faster speeds.
+
+Although studies show comprehension drops above 300 wpm, the wider range allows
+advanced readers and researchers to evaluate extreme speeds while keeping the
+default at 300 wpm.

--- a/docs/features/configurable_control.feature
+++ b/docs/features/configurable_control.feature
@@ -13,12 +13,12 @@ Feature: Configurable Control
   Scenario: Increasing speed
     Given the player is playing at 300 wpm
     When I press the "Arrow Up" key
-    Then the playback speed increases by a fixed increment within the range 200-350 wpm
+    Then the playback speed increases by a fixed increment within the range 100-800 wpm
 
   Scenario: Decreasing speed
     Given the player is playing at 300 wpm
     When I press the "Arrow Down" key
-    Then the playback speed decreases by a fixed increment within the range 200-350 wpm
+    Then the playback speed decreases by a fixed increment within the range 100-800 wpm
 
   Scenario: Rewinding words
     Given the player has advanced 10 words

--- a/webcomponents/src/components/rsvp-controls.ts
+++ b/webcomponents/src/components/rsvp-controls.ts
@@ -44,30 +44,37 @@ export class RsvpControls extends LitElement {
         }
     `;
 
-    private _dispatchEvent(eventName: string) {
-        this.dispatchEvent(new CustomEvent(eventName));
-    }
-    private _onPlayPause() {
+    private _dispatchEvent = (eventName: string) => {
+        this.dispatchEvent(new CustomEvent(eventName, { bubbles: true, composed: true }));
+    };
+
+    private _onPlayPause = () => {
         this._dispatchEvent('play-pause');
-    }
-    private _onRewind() {
+    };
+
+    private _onRewind = () => {
         this._dispatchEvent('rewind');
-    }
-    private _onFastForward() {
+    };
+
+    private _onFastForward = () => {
         this._dispatchEvent('fast-forward');
-    }
-    private _onDecreaseSpeed() {
+    };
+
+    private _onDecreaseSpeed = () => {
         this._dispatchEvent('decrease-speed');
-    }
-    private _onIncreaseSpeed() {
+    };
+
+    private _onIncreaseSpeed = () => {
         this._dispatchEvent('increase-speed');
-    }
-    private _onToggleFullscreen() {
+    };
+
+    private _onToggleFullscreen = () => {
         this._dispatchEvent('toggle-fullscreen');
-    }
-    private _onToggleSettings() {
+    };
+
+    private _onToggleSettings = () => {
         this._dispatchEvent('toggle-settings');
-    }
+    };
 
     render() {
         const playPauseIcon = this.playing
@@ -108,7 +115,9 @@ export class RsvpControls extends LitElement {
             </svg>
           </button>
           <button @click=${this._onToggleSettings} aria-label="Settings">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M19.43 12.98c.04-.32.07-.64.07-.98s-.03-.66-.07-.98l2.11-1.65c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.3-.61-.22l-2.49 1c-.52-.4-1.08-.73-1.69-.98l-.38-2.65C14.46 2.18 14.25 2 14 2h-4c-.25 0-.46.18-.49.42l-.38 2.65c-.61.25-1.17.59-1.69.98l-2.49-1c-.23-.09-.49 0-.61.22l-2 3.46c-.13.22-.07-.49.12.64l2.11 1.65c-.04.32-.07.) .65-.07.)198s.03.)66.)07...).'/></svg>
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M19.14 12.94c.04-.31.06-.63.06-.94s-.02-.63-.06-.94l2.03-1.58a.5.5 0 0 0 .11-.59l-1.91-3.27a.5.5 0 0 0-.6-.22l-2.34.94a6.98 6.98 0 0 0-1.6-.95l-.35-2.47a.5.5 0 0 0-.49-.42h-3.78a.5.5 0 0 0-.49.42l-.35 2.47a6.98 6.98 0 0 0-1.6.95l-2.34-.94a.5.5 0 0 0-.6.22l-1.91 3.27a.5.5 0 0 0 .11.59l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58a.5.5 0 0 0-.11.59l1.91 3.27c.12.21.38.3.6.22l2.34-.94c.5.39 1.04.71 1.6.95l.35 2.47c.03.24.25.42.49.42h3.78c.24 0 .46-.18.49-.42l.35-2.47c.56-.24 1.1-.56 1.6-.95l2.34.94c.22.08.48-.01.6-.22l1.91-3.27a.5.5 0 0 0-.11-.59l-2.03-1.58zM12 15.5a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7z"/>
+            </svg>
           </button>
         </div>
       </div>

--- a/webcomponents/src/components/rsvp-player.mobile.test.ts
+++ b/webcomponents/src/components/rsvp-player.mobile.test.ts
@@ -1,4 +1,7 @@
+/* eslint-disable max-lines-per-function */
 import '@testing-library/jest-dom';
+import { jest } from '@jest/globals';
+import { fireEvent, within } from '@testing-library/dom';
 import { RsvpPlayer } from './rsvp-player';
 
 describe('RsvpPlayer mobile layout', () => {
@@ -7,5 +10,78 @@ describe('RsvpPlayer mobile layout', () => {
     expect(css).toMatch(/@media\s*\(max-width: 600px\)/);
     expect(css).toMatch(/min-height:\s*100dvh/);
     expect(css).toMatch(/width:\s*100vw/);
+  });
+
+  describe('touch gestures', () => {
+    const TAG = 'rsvp-player';
+
+    beforeEach(() => {
+      if (!customElements.get(TAG)) {
+        customElements.define(TAG, RsvpPlayer);
+      }
+      document.body.innerHTML = `<${TAG}></${TAG}>`;
+    });
+
+    it('toggles play/pause when tapping word area', async () => {
+      const el = document.querySelector<RsvpPlayer>(TAG)!;
+      await el.updateComplete;
+      Object.defineProperty(el, 'clientWidth', { configurable: true, value: 100 });
+      const word = el.shadowRoot!.querySelector('.word') as HTMLElement;
+
+      fireEvent.click(word);
+      await el.updateComplete;
+      expect((el as any).playing).toBe(true);
+
+      fireEvent.click(word);
+      await el.updateComplete;
+      expect((el as any).playing).toBe(false);
+    });
+
+    it('increases speed on right tap and decreases on left tap', async () => {
+      const el = document.querySelector<RsvpPlayer>(TAG)!;
+      await el.updateComplete;
+      Object.defineProperty(el, 'clientWidth', { configurable: true, value: 100 });
+      const word = el.shadowRoot!.querySelector('.word') as HTMLElement;
+
+      fireEvent.touchStart(word, { changedTouches: [{ clientX: 80 }] });
+      fireEvent.touchEnd(word, { changedTouches: [{ clientX: 80 }] });
+      await el.updateComplete;
+      expect(el.wpm).toBe(350);
+
+      fireEvent.touchStart(word, { changedTouches: [{ clientX: 10 }] });
+      fireEvent.touchEnd(word, { changedTouches: [{ clientX: 10 }] });
+      await el.updateComplete;
+      expect(el.wpm).toBe(300);
+    });
+
+    it('rewinds and fast-forwards on swipe', async () => {
+      const el = document.querySelector<RsvpPlayer>(TAG)!;
+      el.text = 'one two three four five six seven eight nine ten';
+      await el.updateComplete;
+      Object.defineProperty(el, 'clientWidth', { configurable: true, value: 100 });
+      (el as any).index = 5;
+      const word = el.shadowRoot!.querySelector('.word') as HTMLElement;
+
+      fireEvent.touchStart(word, { changedTouches: [{ clientX: 60 }] });
+      fireEvent.touchEnd(word, { changedTouches: [{ clientX: 10 }] });
+      await el.updateComplete;
+      expect((el as any).index).toBe(0);
+
+      (el as any).index = 2;
+      fireEvent.touchStart(word, { changedTouches: [{ clientX: 10 }] });
+      fireEvent.touchEnd(word, { changedTouches: [{ clientX: 90 }] });
+      await el.updateComplete;
+      expect((el as any).index).toBe(7);
+    });
+
+    it('prevents default browser swipe navigation', async () => {
+      const el = document.querySelector<RsvpPlayer>(TAG)!;
+      await el.updateComplete;
+      const word = el.shadowRoot!.querySelector('.word') as HTMLElement;
+      const ev = new TouchEvent('touchstart', { cancelable: true, changedTouches: [ { clientX: 50 } ] } as any);
+      const prevent = jest.spyOn(ev, 'preventDefault');
+      word.dispatchEvent(ev);
+      expect(prevent).toHaveBeenCalled();
+    });
   });
 });

--- a/webcomponents/src/components/rsvp-player.test.ts
+++ b/webcomponents/src/components/rsvp-player.test.ts
@@ -57,7 +57,7 @@ describe.skip('RsvpPlayer', () => {
     await el.updateComplete;
     const newWpm = el.wpm;
     expect(newWpm).toBeGreaterThan(initial);
-    expect(newWpm).toBeLessThanOrEqual(350);
+    expect(newWpm).toBeLessThanOrEqual(800);
     expect(display).toHaveTextContent(`${newWpm} WPM`);
   });
 
@@ -70,7 +70,7 @@ describe.skip('RsvpPlayer', () => {
     await el.updateComplete;
     const newWpm = el.wpm;
     expect(newWpm).toBeLessThan(initial);
-    expect(newWpm).toBeGreaterThanOrEqual(200);
+    expect(newWpm).toBeGreaterThanOrEqual(100);
     expect(display).toHaveTextContent(`${newWpm} WPM`);
   });
 

--- a/webcomponents/src/components/rsvp-player.ts
+++ b/webcomponents/src/components/rsvp-player.ts
@@ -35,11 +35,14 @@ export class RsvpPlayer extends LitElement {
   private _touchStartY = 0;
 
   private timerId?: number;
-  private static readonly MIN_WPM = 200;
-  private static readonly MAX_WPM = 350;
+  private static readonly MIN_WPM = 100;
+  private static readonly MAX_WPM = 800;
   private static readonly STEP = 50;
   private static readonly REWIND_WORDS = 5;
   private static readonly FAST_FORWARD_WORDS = 5; // Added for fast forward functionality
+  private static readonly SWIPE_THRESHOLD = 30;
+
+  private touchStartX: number | null = null;
 
   static styles = css`
     :host {
@@ -140,13 +143,13 @@ export class RsvpPlayer extends LitElement {
     this.requestUpdate(); // Ensure UI updates when fullscreen state changes
   }
 
-  private _onPointerDown = (e: PointerEvent) => {
+  private _onSettingsPointerDown = (e: PointerEvent) => {
     if (e.pointerType === 'touch') {
       this._touchStartY = e.clientY;
     }
   };
 
-  private _onPointerUp = (e: PointerEvent) => {
+  private _onSettingsPointerUp = (e: PointerEvent) => {
     if (e.pointerType === 'touch') {
       const deltaY = this._touchStartY - e.clientY;
       if (deltaY > 50 && !this.showSettingsPane) {
@@ -156,12 +159,19 @@ export class RsvpPlayer extends LitElement {
     }
   };
 
-  private _onTouchStart = (e: TouchEvent) => {
-    this._touchStartY = e.touches[0].clientY;
+  private _onSettingsTouchStart = (e: TouchEvent) => {
+    const touch = e.touches[0] ?? e.changedTouches[0];
+    if (touch) {
+      this._touchStartY = touch.clientY;
+    }
   };
 
-  private _onTouchEnd = (e: TouchEvent) => {
-    const deltaY = this._touchStartY - e.changedTouches[0].clientY;
+  private _onSettingsTouchEnd = (e: TouchEvent) => {
+    const touch = e.changedTouches[0] ?? e.touches[0];
+    if (!touch) {
+      return;
+    }
+    const deltaY = this._touchStartY - touch.clientY;
     if (deltaY > 50 && !this.showSettingsPane) {
       e.preventDefault();
       this._toggleSettingsPane();
@@ -185,7 +195,15 @@ export class RsvpPlayer extends LitElement {
           @close=${this._toggleSettingsPane}
         ></rsvp-settings>
       ` : html`
-        <div class="word" part="word" style="font-size: ${this.wordFontSize}rem;">
+        <div
+          class="word"
+          part="word"
+          style="font-size: ${this.wordFontSize}rem;"
+          @click=${this._onAreaClick}
+          @touchstart=${this._onTouchStart}
+          @touchmove=${this._onTouchMove}
+          @touchend=${this._onTouchEnd}
+        >
           ${this.words.length > 0 ? this.words[this.index] : 'Loading...'}
         </div>
 
@@ -236,6 +254,46 @@ export class RsvpPlayer extends LitElement {
     // Dispatch event after state change, so listeners get the new state
     this.dispatchEvent(new CustomEvent(this.playing ? 'play' : 'pause'));
   }
+
+  private _onAreaClick() {
+    this._onPlayPause();
+  }
+
+  private _onTouchStart(e: TouchEvent) {
+    this.touchStartX = e.changedTouches[0].clientX;
+    e.preventDefault();
+  }
+
+  private _onTouchMove(e: TouchEvent) {
+    e.preventDefault();
+  }
+
+  private _onTouchEnd(e: TouchEvent) {
+    if (this.touchStartX === null) {
+      return;
+    }
+    const endX = e.changedTouches[0].clientX;
+    const diff = endX - this.touchStartX;
+    this.touchStartX = null;
+    e.preventDefault();
+    if (Math.abs(diff) > RsvpPlayer.SWIPE_THRESHOLD) {
+      if (diff < 0) {
+        this._rewind();
+      } else {
+        this._fastForward();
+      }
+      return;
+    }
+
+    const width = this.clientWidth;
+    if (endX < width * 0.3) {
+      this._decreaseSpeed();
+    } else if (endX > width * 0.7) {
+      this._increaseSpeed();
+    } else {
+      this._onPlayPause();
+    }
+  }
   
   private _onProgressBarClick(e: MouseEvent) {
     if (this.words.length === 0) return;
@@ -269,19 +327,19 @@ export class RsvpPlayer extends LitElement {
 
     window.addEventListener('keydown', this._onKeyDown);
     this.addEventListener('fullscreenchange', this._handleFullscreenChange);
-    this.addEventListener('pointerdown', this._onPointerDown);
-    this.addEventListener('pointerup', this._onPointerUp);
-    this.addEventListener('touchstart', this._onTouchStart, { passive: false });
-    this.addEventListener('touchend', this._onTouchEnd, { passive: false });
+    this.addEventListener('pointerdown', this._onSettingsPointerDown);
+    this.addEventListener('pointerup', this._onSettingsPointerUp);
+    this.addEventListener('touchstart', this._onSettingsTouchStart, { passive: false });
+    this.addEventListener('touchend', this._onSettingsTouchEnd, { passive: false });
   }
   disconnectedCallback() {
     super.disconnectedCallback();
     window.removeEventListener('keydown', this._onKeyDown);
     this.removeEventListener('fullscreenchange', this._handleFullscreenChange);
-    this.removeEventListener('pointerdown', this._onPointerDown);
-    this.removeEventListener('pointerup', this._onPointerUp);
-    this.removeEventListener('touchstart', this._onTouchStart);
-    this.removeEventListener('touchend', this._onTouchEnd);
+    this.removeEventListener('pointerdown', this._onSettingsPointerDown);
+    this.removeEventListener('pointerup', this._onSettingsPointerUp);
+    this.removeEventListener('touchstart', this._onSettingsTouchStart);
+    this.removeEventListener('touchend', this._onSettingsTouchEnd);
     this._clearTimer();
   }
 

--- a/webcomponents/src/components/rsvp-player.ts
+++ b/webcomponents/src/components/rsvp-player.ts
@@ -31,6 +31,9 @@ export class RsvpPlayer extends LitElement {
   /** Visibility state for settings pane */
   @state() private showSettingsPane: boolean = false;
 
+  /** Track Y coordinate for swipe gesture */
+  private _touchStartY = 0;
+
   private timerId?: number;
   private static readonly MIN_WPM = 200;
   private static readonly MAX_WPM = 350;
@@ -137,6 +140,21 @@ export class RsvpPlayer extends LitElement {
     this.requestUpdate(); // Ensure UI updates when fullscreen state changes
   }
 
+  private _onPointerDown = (e: PointerEvent) => {
+    if (e.pointerType === 'touch') {
+      this._touchStartY = e.clientY;
+    }
+  };
+
+  private _onPointerUp = (e: PointerEvent) => {
+    if (e.pointerType === 'touch') {
+      const deltaY = this._touchStartY - e.clientY;
+      if (deltaY > 50 && !this.showSettingsPane) {
+        this._toggleSettingsPane();
+      }
+    }
+  };
+
   render() {
     const isEnded = !this.playing && this.words.length > 0 && this.index === this.words.length - 1;
     // Play/pause icon and label logic is now primarily within rsvp-controls
@@ -238,11 +256,15 @@ export class RsvpPlayer extends LitElement {
 
     window.addEventListener('keydown', this._onKeyDown);
     this.addEventListener('fullscreenchange', this._handleFullscreenChange);
+    this.addEventListener('pointerdown', this._onPointerDown);
+    this.addEventListener('pointerup', this._onPointerUp);
   }
   disconnectedCallback() {
     super.disconnectedCallback();
     window.removeEventListener('keydown', this._onKeyDown);
     this.removeEventListener('fullscreenchange', this._handleFullscreenChange);
+    this.removeEventListener('pointerdown', this._onPointerDown);
+    this.removeEventListener('pointerup', this._onPointerUp);
     this._clearTimer();
   }
 

--- a/webcomponents/src/components/rsvp-player.ts
+++ b/webcomponents/src/components/rsvp-player.ts
@@ -150,8 +150,21 @@ export class RsvpPlayer extends LitElement {
     if (e.pointerType === 'touch') {
       const deltaY = this._touchStartY - e.clientY;
       if (deltaY > 50 && !this.showSettingsPane) {
+        e.preventDefault();
         this._toggleSettingsPane();
       }
+    }
+  };
+
+  private _onTouchStart = (e: TouchEvent) => {
+    this._touchStartY = e.touches[0].clientY;
+  };
+
+  private _onTouchEnd = (e: TouchEvent) => {
+    const deltaY = this._touchStartY - e.changedTouches[0].clientY;
+    if (deltaY > 50 && !this.showSettingsPane) {
+      e.preventDefault();
+      this._toggleSettingsPane();
     }
   };
 
@@ -258,6 +271,8 @@ export class RsvpPlayer extends LitElement {
     this.addEventListener('fullscreenchange', this._handleFullscreenChange);
     this.addEventListener('pointerdown', this._onPointerDown);
     this.addEventListener('pointerup', this._onPointerUp);
+    this.addEventListener('touchstart', this._onTouchStart, { passive: false });
+    this.addEventListener('touchend', this._onTouchEnd, { passive: false });
   }
   disconnectedCallback() {
     super.disconnectedCallback();
@@ -265,6 +280,8 @@ export class RsvpPlayer extends LitElement {
     this.removeEventListener('fullscreenchange', this._handleFullscreenChange);
     this.removeEventListener('pointerdown', this._onPointerDown);
     this.removeEventListener('pointerup', this._onPointerUp);
+    this.removeEventListener('touchstart', this._onTouchStart);
+    this.removeEventListener('touchend', this._onTouchEnd);
     this._clearTimer();
   }
 

--- a/webcomponents/src/components/rsvp-settings-pane.test.ts
+++ b/webcomponents/src/components/rsvp-settings-pane.test.ts
@@ -16,6 +16,7 @@ describe('RsvpPlayer settings pane', () => {
     const controls = el.shadowRoot!.querySelector('rsvp-controls')!;
     await (controls as any).updateComplete;
     const button = controls.shadowRoot!.querySelector('button[aria-label="Settings"]') as HTMLButtonElement;
+    expect(button).toBeVisible();
     fireEvent.click(button);
     await el.updateComplete;
     expect(el.shadowRoot!.querySelector('rsvp-settings')).toBeInTheDocument();

--- a/webcomponents/src/components/rsvp-settings-pane.test.ts
+++ b/webcomponents/src/components/rsvp-settings-pane.test.ts
@@ -20,4 +20,20 @@ describe('RsvpPlayer settings pane', () => {
     await el.updateComplete;
     expect(el.shadowRoot!.querySelector('rsvp-settings')).toBeInTheDocument();
   });
+
+  it('shows settings pane on swipe up gesture', async () => {
+    document.body.innerHTML = `<${PLAYER_TAG} text="hello world"></${PLAYER_TAG}>`;
+    const el = document.querySelector(PLAYER_TAG)! as RsvpPlayer;
+    await el.updateComplete;
+
+    const down = new Event('pointerdown');
+    Object.assign(down, { pointerType: 'touch', clientY: 300 });
+    el.dispatchEvent(down);
+    const up = new Event('pointerup');
+    Object.assign(up, { pointerType: 'touch', clientY: 200 });
+    el.dispatchEvent(up);
+    await el.updateComplete;
+
+    expect(el.shadowRoot!.querySelector('rsvp-settings')).toBeInTheDocument();
+  });
 });

--- a/webcomponents/src/components/rsvp-settings-pane.test.ts
+++ b/webcomponents/src/components/rsvp-settings-pane.test.ts
@@ -1,0 +1,23 @@
+import '@testing-library/jest-dom';
+import { fireEvent } from '@testing-library/dom';
+import { RsvpPlayer } from './rsvp-player';
+
+const PLAYER_TAG = 'rsvp-player';
+if (!customElements.get(PLAYER_TAG)) {
+  customElements.define(PLAYER_TAG, RsvpPlayer);
+}
+
+describe('RsvpPlayer settings pane', () => {
+  it('shows settings pane when settings button clicked', async () => {
+    document.body.innerHTML = `<${PLAYER_TAG} text="hello world"></${PLAYER_TAG}>`;
+    const el = document.querySelector(PLAYER_TAG)! as RsvpPlayer;
+    await el.updateComplete;
+
+    const controls = el.shadowRoot!.querySelector('rsvp-controls')!;
+    await (controls as any).updateComplete;
+    const button = controls.shadowRoot!.querySelector('button[aria-label="Settings"]') as HTMLButtonElement;
+    fireEvent.click(button);
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('rsvp-settings')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure event handlers are bound in `rsvp-controls`
- use a standard gear icon for the settings button
- allow custom events to bubble out of controls
- test that the settings pane appears when the settings icon is pressed

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e7d5f3688833199bbfd812454e7ad