### PR TITLE
Add mobile gesture controls

### DIFF
--- a/webcomponents/src/components/rsvp-player.mobile.test.ts
+++ b/webcomponents/src/components/rsvp-player.mobile.test.ts
@@ -1,4 +1,6 @@
+/* eslint-disable max-lines-per-function */
 import '@testing-library/jest-dom';
+import { jest } from '@jest/globals';
 import { fireEvent, within } from '@testing-library/dom';
 import { RsvpPlayer } from './rsvp-player';
 
@@ -70,6 +72,16 @@ describe('RsvpPlayer mobile layout', () => {
       fireEvent.touchEnd(word, { changedTouches: [{ clientX: 90 }] });
       await el.updateComplete;
       expect((el as any).index).toBe(7);
+    });
+
+    it('prevents default browser swipe navigation', async () => {
+      const el = document.querySelector<RsvpPlayer>(TAG)!;
+      await el.updateComplete;
+      const word = el.shadowRoot!.querySelector('.word') as HTMLElement;
+      const ev = new TouchEvent('touchstart', { cancelable: true, changedTouches: [ { clientX: 50 } ] } as any);
+      const prevent = jest.spyOn(ev, 'preventDefault');
+      word.dispatchEvent(ev);
+      expect(prevent).toHaveBeenCalled();
     });
   });
 });

--- a/webcomponents/src/components/rsvp-player.mobile.test.ts
+++ b/webcomponents/src/components/rsvp-player.mobile.test.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import { fireEvent, within } from '@testing-library/dom';
 import { RsvpPlayer } from './rsvp-player';
 
 describe('RsvpPlayer mobile layout', () => {
@@ -7,5 +8,68 @@ describe('RsvpPlayer mobile layout', () => {
     expect(css).toMatch(/@media\s*\(max-width: 600px\)/);
     expect(css).toMatch(/min-height:\s*100dvh/);
     expect(css).toMatch(/width:\s*100vw/);
+  });
+
+  describe('touch gestures', () => {
+    const TAG = 'rsvp-player';
+
+    beforeEach(() => {
+      if (!customElements.get(TAG)) {
+        customElements.define(TAG, RsvpPlayer);
+      }
+      document.body.innerHTML = `<${TAG}></${TAG}>`;
+    });
+
+    it('toggles play/pause when tapping word area', async () => {
+      const el = document.querySelector<RsvpPlayer>(TAG)!;
+      await el.updateComplete;
+      Object.defineProperty(el, 'clientWidth', { configurable: true, value: 100 });
+      const word = el.shadowRoot!.querySelector('.word') as HTMLElement;
+
+      fireEvent.click(word);
+      await el.updateComplete;
+      expect((el as any).playing).toBe(true);
+
+      fireEvent.click(word);
+      await el.updateComplete;
+      expect((el as any).playing).toBe(false);
+    });
+
+    it('increases speed on right tap and decreases on left tap', async () => {
+      const el = document.querySelector<RsvpPlayer>(TAG)!;
+      await el.updateComplete;
+      Object.defineProperty(el, 'clientWidth', { configurable: true, value: 100 });
+      const word = el.shadowRoot!.querySelector('.word') as HTMLElement;
+
+      fireEvent.touchStart(word, { changedTouches: [{ clientX: 80 }] });
+      fireEvent.touchEnd(word, { changedTouches: [{ clientX: 80 }] });
+      await el.updateComplete;
+      expect(el.wpm).toBe(350);
+
+      fireEvent.touchStart(word, { changedTouches: [{ clientX: 10 }] });
+      fireEvent.touchEnd(word, { changedTouches: [{ clientX: 10 }] });
+      await el.updateComplete;
+      expect(el.wpm).toBe(300);
+    });
+
+    it('rewinds and fast-forwards on swipe', async () => {
+      const el = document.querySelector<RsvpPlayer>(TAG)!;
+      el.text = 'one two three four five six seven eight nine ten';
+      await el.updateComplete;
+      Object.defineProperty(el, 'clientWidth', { configurable: true, value: 100 });
+      (el as any).index = 5;
+      const word = el.shadowRoot!.querySelector('.word') as HTMLElement;
+
+      fireEvent.touchStart(word, { changedTouches: [{ clientX: 60 }] });
+      fireEvent.touchEnd(word, { changedTouches: [{ clientX: 10 }] });
+      await el.updateComplete;
+      expect((el as any).index).toBe(0);
+
+      (el as any).index = 2;
+      fireEvent.touchStart(word, { changedTouches: [{ clientX: 10 }] });
+      fireEvent.touchEnd(word, { changedTouches: [{ clientX: 90 }] });
+      await el.updateComplete;
+      expect((el as any).index).toBe(7);
+    });
   });
 });

--- a/webcomponents/src/components/rsvp-player.ts
+++ b/webcomponents/src/components/rsvp-player.ts
@@ -163,6 +163,7 @@ export class RsvpPlayer extends LitElement {
           style="font-size: ${this.wordFontSize}rem;"
           @click=${this._onAreaClick}
           @touchstart=${this._onTouchStart}
+          @touchmove=${this._onTouchMove}
           @touchend=${this._onTouchEnd}
         >
           ${this.words.length > 0 ? this.words[this.index] : 'Loading...'}
@@ -222,6 +223,11 @@ export class RsvpPlayer extends LitElement {
 
   private _onTouchStart(e: TouchEvent) {
     this.touchStartX = e.changedTouches[0].clientX;
+    e.preventDefault();
+  }
+
+  private _onTouchMove(e: TouchEvent) {
+    e.preventDefault();
   }
 
   private _onTouchEnd(e: TouchEvent) {

--- a/webcomponents/src/components/rsvp-player.ts
+++ b/webcomponents/src/components/rsvp-player.ts
@@ -37,6 +37,9 @@ export class RsvpPlayer extends LitElement {
   private static readonly STEP = 50;
   private static readonly REWIND_WORDS = 5;
   private static readonly FAST_FORWARD_WORDS = 5; // Added for fast forward functionality
+  private static readonly SWIPE_THRESHOLD = 30;
+
+  private touchStartX: number | null = null;
 
   static styles = css`
     :host {
@@ -154,7 +157,14 @@ export class RsvpPlayer extends LitElement {
           @close=${this._toggleSettingsPane}
         ></rsvp-settings>
       ` : html`
-        <div class="word" part="word" style="font-size: ${this.wordFontSize}rem;">
+        <div
+          class="word"
+          part="word"
+          style="font-size: ${this.wordFontSize}rem;"
+          @click=${this._onAreaClick}
+          @touchstart=${this._onTouchStart}
+          @touchend=${this._onTouchEnd}
+        >
           ${this.words.length > 0 ? this.words[this.index] : 'Loading...'}
         </div>
 
@@ -204,6 +214,41 @@ export class RsvpPlayer extends LitElement {
     }
     // Dispatch event after state change, so listeners get the new state
     this.dispatchEvent(new CustomEvent(this.playing ? 'play' : 'pause'));
+  }
+
+  private _onAreaClick() {
+    this._onPlayPause();
+  }
+
+  private _onTouchStart(e: TouchEvent) {
+    this.touchStartX = e.changedTouches[0].clientX;
+  }
+
+  private _onTouchEnd(e: TouchEvent) {
+    if (this.touchStartX === null) {
+      return;
+    }
+    const endX = e.changedTouches[0].clientX;
+    const diff = endX - this.touchStartX;
+    this.touchStartX = null;
+    e.preventDefault();
+    if (Math.abs(diff) > RsvpPlayer.SWIPE_THRESHOLD) {
+      if (diff < 0) {
+        this._rewind();
+      } else {
+        this._fastForward();
+      }
+      return;
+    }
+
+    const width = this.clientWidth;
+    if (endX < width * 0.3) {
+      this._decreaseSpeed();
+    } else if (endX > width * 0.7) {
+      this._increaseSpeed();
+    } else {
+      this._onPlayPause();
+    }
   }
   
   private _onProgressBarClick(e: MouseEvent) {


### PR DESCRIPTION
## Summary
- add touch gesture support to player for play/pause, speed, and seeking
- test new mobile gestures

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e7e32032883319689be07913a03c6