### PR TITLE
Fix fullscreen icon rendering

### DIFF
--- a/webcomponents/src/components/rsvp-controls.test.ts
+++ b/webcomponents/src/components/rsvp-controls.test.ts
@@ -1,0 +1,11 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const file = fs.readFileSync(path.join(path.dirname(new URL(import.meta.url).pathname), 'rsvp-controls.ts'), 'utf8');
+
+describe('rsvp-controls icons', () => {
+  it('uses standard fullscreen icons', () => {
+    expect(file).toContain('M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zm-2-4h2V7h-3V5h5v5z');
+    expect(file).toContain('M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z');
+  });
+});

--- a/webcomponents/src/components/rsvp-controls.ts
+++ b/webcomponents/src/components/rsvp-controls.ts
@@ -5,10 +5,12 @@ export class RsvpControls extends LitElement {
     static properties = {
         playing: { type: Boolean },
         wpm: { type: Number },
+        isFullscreen: { type: Boolean },
     };
 
     @property({ type: Boolean }) playing: boolean = false;
     @property({ type: Number }) wpm: number = 300;
+    @property({ type: Boolean }) isFullscreen: boolean = false;
 
     static styles = css`
         .controls {
@@ -100,11 +102,18 @@ export class RsvpControls extends LitElement {
           <button @click=${this._onIncreaseSpeed} aria-label="Increase speed">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>
           </button>
-          <button @click=${this._onToggleFullscreen} aria-label="Toggle Fullscreen">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-              ${this.playing /* placeholder for proper fullscreenElement check */
-                ? html`<path d="${exitFullscreenPath}"/>`
-                : html`<path d="${enterFullscreenPath}"/>`}
+          <button
+            @click=${this._onToggleFullscreen}
+            aria-label=${this.isFullscreen ? 'Exit Fullscreen' : 'Enter Fullscreen'}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="currentColor">
+              ${this.isFullscreen
+                ? html`<path d="${exitFullscreenPath}" />`
+                : html`<path d="${enterFullscreenPath}" />`}
             </svg>
           </button>
           <button @click=${this._onToggleSettings} aria-label="Settings">

--- a/webcomponents/src/components/rsvp-player.mobile.test.ts
+++ b/webcomponents/src/components/rsvp-player.mobile.test.ts
@@ -1,11 +1,23 @@
 import '@testing-library/jest-dom';
 import { RsvpPlayer } from './rsvp-player';
 
+const TAG = 'rsvp-player';
+
 describe('RsvpPlayer mobile layout', () => {
   it('includes mobile fullscreen styles', () => {
     const css = Array.isArray(RsvpPlayer.styles) ? RsvpPlayer.styles.map(s => s.cssText).join('') : RsvpPlayer.styles.cssText;
     expect(css).toMatch(/@media\s*\(max-width: 600px\)/);
     expect(css).toMatch(/min-height:\s*100dvh/);
     expect(css).toMatch(/width:\s*100vw/);
+  });
+
+  it('renders fullscreen control', async () => {
+    document.body.innerHTML = `<${TAG}></${TAG}>`;
+    const el = document.querySelector<RsvpPlayer>(TAG)!;
+    await el.updateComplete;
+    const controls = el.shadowRoot!.querySelector('rsvp-controls')!;
+    await (controls as any).updateComplete;
+    const button = (controls.shadowRoot as unknown as HTMLElement).querySelector('button[aria-label*="Fullscreen"]');
+    expect(button).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- toggle fullscreen icon based on fullscreen state
- add regression test for fullscreen icons
- verify fullscreen control shows on mobile

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e80c619d08331801a38fbcea811b3