### PR TITLE
Update agent and copilot rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,10 @@ This repository uses TypeScript and Lit to build web components, a browser exten
 - When adding new features, include unit tests and ensure existing tests keep ≥90% coverage.
 - GitHub Actions run `npm run lint` and `npm test`. Make sure they succeed locally before pushing.
 
+- Always `git pull` from origin or merge the PR's destination branch before beginning a task. If origin isn't available, use `main`. Resolve any merge conflicts first.
+- Record design decisions that deviate from existing docs under `docs/design/decisions/`.
+- Take a test-driven approach, especially for new UI behaviour.
+- Document preferences from conversations, noting whether they are standards or one-off exceptions.
+- Override existing features gracefully, e.g. intercept swipe gestures so mobile browsers don't navigate back.
+- Ensure documentation (including `README.md`) stays in sync with the latest code.
+

--- a/COPILOT.md
+++ b/COPILOT.md
@@ -9,3 +9,5 @@ This project prefers clean, idiomatic TypeScript. When using Copilot suggestions
 - Run `npm run lint` and `npm test` to verify before committing.
 - Respect the DRY, SRP and KISS principles. Refactor Boy Scout style and lean on the linter to catch smells from SonarJS and Unicorn. Run the linter when editing existing files and tidy up warnings as you go.
 - Embrace Uncle Bob's Clean Code guidelines. Keep functions short, use expressive names, and aim for modular design.
+- Always sync with origin or the PR's destination branch (default `main`) before committing and resolve any merge conflicts.
+- Keep documentation up to date with the latest code and record design deviations under `docs/design/decisions/`.


### PR DESCRIPTION
## Summary
- clarify merge workflow and docs rule in AGENTS
- update Copilot usage guidelines to match

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e95b006808331a8ca3c4030fb68c8