### PR TITLE
Improve mobile settings UX

### DIFF
--- a/webcomponents/src/components/rsvp-settings.test.ts
+++ b/webcomponents/src/components/rsvp-settings.test.ts
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom';
+import { fireEvent } from '@testing-library/dom';
+import { jest } from '@jest/globals';
+import './rsvp-settings';
+import type { RsvpSettings } from './rsvp-settings';
+
+const TAG = 'rsvp-settings';
+
+describe('RsvpSettings', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `<${TAG}></${TAG}>`;
+  });
+
+  it('shows paste text area by default', async () => {
+    const el = document.querySelector(TAG) as RsvpSettings;
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('textarea')).toBeInTheDocument();
+  });
+
+  it('switches to url input', async () => {
+    const el = document.querySelector(TAG) as RsvpSettings;
+    await el.updateComplete;
+    const buttons = el.shadowRoot!.querySelectorAll('.tabs button');
+    fireEvent.click(buttons[1]!);
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('input[type="url"]')).toBeInTheDocument();
+  });
+
+  it('loads content from url', async () => {
+    const el = document.querySelector(TAG) as RsvpSettings;
+    el.mode = 'url';
+    await el.updateComplete;
+    const fetchMock = jest.fn(() => Promise.resolve({
+      text: async () => '<html><body>Hello World</body></html>'
+    }));
+    (global as any).fetch = fetchMock;
+    el.url = 'http://example.com';
+    await el.updateComplete;
+    const loadButton = el.shadowRoot!.querySelector('.load-url') as HTMLButtonElement;
+    const listener = jest.fn();
+    el.addEventListener('text-change', listener);
+    fireEvent.click(loadButton);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledWith('http://example.com');
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ detail: 'Hello World' }));
+  });
+});

--- a/webcomponents/src/components/rsvp-settings.ts
+++ b/webcomponents/src/components/rsvp-settings.ts
@@ -4,27 +4,53 @@ import { property } from 'lit/decorators.js';
 export class RsvpSettings extends LitElement {
   @property({ type: String }) text: string = '';
   @property({ type: Number }) wordFontSize: number = 3;
+  @property({ type: String }) mode: 'paste' | 'url' = 'paste';
+  @property({ type: String }) url: string = '';
 
   static styles = css`
     :host {
       position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
+      inset: 0;
       background-color: rgba(0, 0, 0, 0.9);
       display: flex;
       flex-direction: column;
       align-items: center;
-      justify-content: center;
+      justify-content: flex-start;
       padding: 20px;
       z-index: 10;
+      overflow-y: auto;
+    }
+
+    @media (max-width: 600px) {
+      :host {
+        padding: 10px;
+      }
     }
 
     .settings-pane div {
       margin-bottom: 15px;
       width: 80%;
       max-width: 400px;
+    }
+
+    .tabs {
+      display: flex;
+      gap: 8px;
+      width: 100%;
+      max-width: 400px;
+    }
+
+    .tabs button {
+      flex: 1;
+      padding: 8px;
+      border: 1px solid #555;
+      background-color: #222;
+      color: #fff;
+      cursor: pointer;
+    }
+
+    .tabs button.active {
+      background-color: #ff0000;
     }
 
     .settings-pane label {
@@ -35,7 +61,8 @@ export class RsvpSettings extends LitElement {
 
     .settings-pane textarea,
     .settings-pane input[type="number"],
-    .settings-pane input[type="range"] {
+    .settings-pane input[type="range"],
+    .settings-pane input[type="url"] {
       width: 100%;
       padding: 8px;
       border-radius: 4px;
@@ -75,17 +102,54 @@ export class RsvpSettings extends LitElement {
     this.dispatchEvent(new CustomEvent('font-size-change', { detail: value }));
   }
 
+  private _onUrlInput(e: Event) {
+    const target = e.target as HTMLInputElement;
+    this.url = target.value;
+  }
+
+  private async _loadUrl() {
+    if (!this.url) return;
+    try {
+      const res = await fetch(this.url);
+      const text = await res.text();
+      const doc = new DOMParser().parseFromString(text, 'text/html');
+      const bodyText = doc.body.textContent ?? '';
+      this.dispatchEvent(
+        new CustomEvent('text-change', { detail: bodyText.trim() })
+      );
+    } catch {
+      // Swallow network errors
+    }
+  }
+
   private _onClose() {
     this.dispatchEvent(new CustomEvent('close'));
   }
 
   render() {
+    const pasteActive = this.mode === 'paste';
     return html`
       <div class="settings-pane">
-        <div>
-          <label for="text-input">Text to Display:</label>
-          <textarea id="text-input" .value=${this.text} @input=${this._onTextInput}></textarea>
-        </div>
+        <nav class="tabs" role="tablist">
+          <button class=${pasteActive ? 'active' : ''} role="tab" aria-selected=${pasteActive} @click=${() => { this.mode = 'paste'; }}>
+            Paste Text
+          </button>
+          <button class=${pasteActive ? '' : 'active'} role="tab" aria-selected=${!pasteActive} @click=${() => { this.mode = 'url'; }}>
+            From URL
+          </button>
+        </nav>
+        ${pasteActive ? html`
+          <div>
+            <label for="text-input">Text to Display:</label>
+            <textarea id="text-input" .value=${this.text} @input=${this._onTextInput}></textarea>
+          </div>
+        ` : html`
+          <div>
+            <label for="url-input">URL to Load:</label>
+            <input id="url-input" type="url" .value=${this.url} @input=${this._onUrlInput}>
+            <button class="load-url" @click=${this._loadUrl}>Load Content</button>
+          </div>
+        `}
         <div>
           <label for="font-size-input">Font Size (rem): ${this.wordFontSize}</label>
           <div style="display: flex; align-items: center; gap: 8px;">


### PR DESCRIPTION
## Summary
- redesign `rsvp-settings` overlay for mobile
- support pasting text or loading from a URL
- add unit tests for the settings component

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685eddf445448331ba374dd1e4e1a355