### PR TITLE
Add swipe-down close gesture

### DIFF
--- a/webcomponents/src/components/rsvp-settings-pane.test.ts
+++ b/webcomponents/src/components/rsvp-settings-pane.test.ts
@@ -3,13 +3,15 @@ import { fireEvent } from '@testing-library/dom';
 import { RsvpPlayer } from './rsvp-player';
 
 const PLAYER_TAG = 'rsvp-player';
+const SETTINGS_TAG = 'rsvp-settings';
+const TEXT = 'hello world';
 if (!customElements.get(PLAYER_TAG)) {
   customElements.define(PLAYER_TAG, RsvpPlayer);
 }
 
 describe('RsvpPlayer settings pane', () => {
   it('shows settings pane when settings button clicked', async () => {
-    document.body.innerHTML = `<${PLAYER_TAG} text="hello world"></${PLAYER_TAG}>`;
+    document.body.innerHTML = `<${PLAYER_TAG} text="${TEXT}"></${PLAYER_TAG}>`;
     const el = document.querySelector(PLAYER_TAG)! as RsvpPlayer;
     await el.updateComplete;
 
@@ -22,11 +24,11 @@ describe('RsvpPlayer settings pane', () => {
     expect(icon).toBeTruthy();
     fireEvent.click(button);
     await el.updateComplete;
-    expect(el.shadowRoot!.querySelector('rsvp-settings')).toBeInTheDocument();
+    expect(el.shadowRoot!.querySelector(SETTINGS_TAG)).toBeInTheDocument();
   });
 
   it('shows settings pane on swipe up gesture', async () => {
-    document.body.innerHTML = `<${PLAYER_TAG} text="hello world"></${PLAYER_TAG}>`;
+    document.body.innerHTML = `<${PLAYER_TAG} text="${TEXT}"></${PLAYER_TAG}>`;
     const el = document.querySelector(PLAYER_TAG)! as RsvpPlayer;
     await el.updateComplete;
 
@@ -38,6 +40,29 @@ describe('RsvpPlayer settings pane', () => {
     el.dispatchEvent(up);
     await el.updateComplete;
 
-    expect(el.shadowRoot!.querySelector('rsvp-settings')).toBeInTheDocument();
+    expect(el.shadowRoot!.querySelector(SETTINGS_TAG)).toBeInTheDocument();
+  });
+
+  it('closes settings pane on swipe down gesture', async () => {
+    document.body.innerHTML = `<${PLAYER_TAG} text="${TEXT}"></${PLAYER_TAG}>`;
+    const el = document.querySelector(PLAYER_TAG)! as RsvpPlayer;
+    await el.updateComplete;
+
+    const controls = el.shadowRoot!.querySelector('rsvp-controls')!;
+    await (controls as any).updateComplete;
+    const button = controls.shadowRoot!.querySelector('button[aria-label="Settings"]') as HTMLButtonElement;
+    fireEvent.click(button);
+    await el.updateComplete;
+    const settings = el.shadowRoot!.querySelector(SETTINGS_TAG)!;
+
+    const down = new Event('pointerdown');
+    Object.assign(down, { pointerType: 'touch', clientY: 100 });
+    settings.dispatchEvent(down);
+    const up = new Event('pointerup');
+    Object.assign(up, { pointerType: 'touch', clientY: 200 });
+    settings.dispatchEvent(up);
+    await el.updateComplete;
+
+    expect(el.shadowRoot!.querySelector(SETTINGS_TAG)).not.toBeInTheDocument();
   });
 });

--- a/webcomponents/src/components/rsvp-settings.ts
+++ b/webcomponents/src/components/rsvp-settings.ts
@@ -126,6 +126,59 @@ export class RsvpSettings extends LitElement {
     this.dispatchEvent(new CustomEvent('close'));
   }
 
+  private _touchStartY = 0;
+
+  private _onPointerDown = (e: PointerEvent) => {
+    if (e.pointerType === 'touch') {
+      this._touchStartY = e.clientY;
+    }
+  };
+
+  private _onPointerUp = (e: PointerEvent) => {
+    if (e.pointerType === 'touch') {
+      const deltaY = e.clientY - this._touchStartY;
+      if (deltaY > 50) {
+        e.preventDefault();
+        this._onClose();
+      }
+    }
+  };
+
+  private _onTouchStart = (e: TouchEvent) => {
+    const touch = e.touches[0] ?? e.changedTouches[0];
+    if (touch) {
+      this._touchStartY = touch.clientY;
+    }
+  };
+
+  private _onTouchEnd = (e: TouchEvent) => {
+    const touch = e.changedTouches[0] ?? e.touches[0];
+    if (!touch) {
+      return;
+    }
+    const deltaY = touch.clientY - this._touchStartY;
+    if (deltaY > 50) {
+      e.preventDefault();
+      this._onClose();
+    }
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('pointerdown', this._onPointerDown);
+    this.addEventListener('pointerup', this._onPointerUp);
+    this.addEventListener('touchstart', this._onTouchStart, { passive: false });
+    this.addEventListener('touchend', this._onTouchEnd, { passive: false });
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener('pointerdown', this._onPointerDown);
+    this.removeEventListener('pointerup', this._onPointerUp);
+    this.removeEventListener('touchstart', this._onTouchStart);
+    this.removeEventListener('touchend', this._onTouchEnd);
+  }
+
   render() {
     const pasteActive = this.mode === 'paste';
     return html`


### PR DESCRIPTION
## Summary
- add gesture detection to `rsvp-settings` to close when swiped down
- test closing settings pane on swipe down

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ee959418c8331ab2ae1f6e2426fdd