### PR TITLE
Add swipe-down close gesture

### DIFF
--- a/webcomponents/index.html
+++ b/webcomponents/index.html
@@ -5,8 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Speed Reader</title>
   <link href="/src/styles.css" rel="stylesheet" />
+  <link rel="manifest" href="/manifest.webmanifest" />
+  <style>
+    html, body {
+      overscroll-behavior: none;
+      height: 100%;
+      margin: 0;
+    }
+  </style>
 </head>
-<body style="margin:0;">
+<body>
   <rsvp-player text="This is a demo of the RSVP player. Use the controls or keyboard to play, pause, and adjust speed."></rsvp-player>
   <script type="module" src="/src/main.ts"></script>
 </body>

--- a/webcomponents/manifest.webmanifest
+++ b/webcomponents/manifest.webmanifest
@@ -1,0 +1,8 @@
+{
+  "name": "Speed Reader",
+  "short_name": "Speed",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000"
+}

--- a/webcomponents/src/components/rsvp-settings-pane.test.ts
+++ b/webcomponents/src/components/rsvp-settings-pane.test.ts
@@ -1,32 +1,38 @@
 import '@testing-library/jest-dom';
 import { fireEvent } from '@testing-library/dom';
+import { jest } from '@jest/globals';
 import { RsvpPlayer } from './rsvp-player';
 
 const PLAYER_TAG = 'rsvp-player';
+const SETTINGS_TAG = 'rsvp-settings';
+const CONTROLS_TAG = 'rsvp-controls';
+const SETTINGS_BUTTON_SELECTOR = 'button[aria-label="Settings"]';
+const TEXT = 'hello world';
+const TEMPLATE = `<${PLAYER_TAG} text="${TEXT}"></${PLAYER_TAG}>`;
 if (!customElements.get(PLAYER_TAG)) {
   customElements.define(PLAYER_TAG, RsvpPlayer);
 }
 
 describe('RsvpPlayer settings pane', () => {
   it('shows settings pane when settings button clicked', async () => {
-    document.body.innerHTML = `<${PLAYER_TAG} text="hello world"></${PLAYER_TAG}>`;
+    document.body.innerHTML = TEMPLATE;
     const el = document.querySelector(PLAYER_TAG)! as RsvpPlayer;
     await el.updateComplete;
 
-    const controls = el.shadowRoot!.querySelector('rsvp-controls')!;
+    const controls = el.shadowRoot!.querySelector(CONTROLS_TAG)!;
     await (controls as any).updateComplete;
-    const button = controls.shadowRoot!.querySelector('button[aria-label="Settings"]') as HTMLButtonElement;
+    const button = controls.shadowRoot!.querySelector(SETTINGS_BUTTON_SELECTOR) as HTMLButtonElement;
     expect(button).toBeVisible();
     expect(button.getAttribute('part')).toBe('settings-button');
     const icon = button.querySelector('svg');
     expect(icon).toBeTruthy();
     fireEvent.click(button);
     await el.updateComplete;
-    expect(el.shadowRoot!.querySelector('rsvp-settings')).toBeInTheDocument();
+    expect(el.shadowRoot!.querySelector(SETTINGS_TAG)).toBeInTheDocument();
   });
 
   it('shows settings pane on swipe up gesture', async () => {
-    document.body.innerHTML = `<${PLAYER_TAG} text="hello world"></${PLAYER_TAG}>`;
+    document.body.innerHTML = TEMPLATE;
     const el = document.querySelector(PLAYER_TAG)! as RsvpPlayer;
     await el.updateComplete;
 
@@ -38,6 +44,47 @@ describe('RsvpPlayer settings pane', () => {
     el.dispatchEvent(up);
     await el.updateComplete;
 
-    expect(el.shadowRoot!.querySelector('rsvp-settings')).toBeInTheDocument();
+    expect(el.shadowRoot!.querySelector(SETTINGS_TAG)).toBeInTheDocument();
+  });
+
+  it('closes settings pane on swipe down gesture', async () => {
+    document.body.innerHTML = TEMPLATE;
+    const el = document.querySelector(PLAYER_TAG)! as RsvpPlayer;
+    await el.updateComplete;
+
+    const controls = el.shadowRoot!.querySelector(CONTROLS_TAG)!;
+    await (controls as any).updateComplete;
+    const button = controls.shadowRoot!.querySelector(SETTINGS_BUTTON_SELECTOR) as HTMLButtonElement;
+    fireEvent.click(button);
+    await el.updateComplete;
+    const settings = el.shadowRoot!.querySelector(SETTINGS_TAG)!;
+
+    const down = new Event('pointerdown');
+    Object.assign(down, { pointerType: 'touch', clientY: 100 });
+    settings.dispatchEvent(down);
+    const up = new Event('pointerup');
+    Object.assign(up, { pointerType: 'touch', clientY: 200 });
+    settings.dispatchEvent(up);
+    await el.updateComplete;
+
+    expect(el.shadowRoot!.querySelector(SETTINGS_TAG)).not.toBeInTheDocument();
+  });
+
+  it('prevents default page refresh when swiping', async () => {
+    document.body.innerHTML = TEMPLATE;
+    const el = document.querySelector(PLAYER_TAG)! as RsvpPlayer;
+    await el.updateComplete;
+
+    const controls = el.shadowRoot!.querySelector(CONTROLS_TAG)!;
+    await (controls as any).updateComplete;
+    const button = controls.shadowRoot!.querySelector(SETTINGS_BUTTON_SELECTOR) as HTMLButtonElement;
+    fireEvent.click(button);
+    await el.updateComplete;
+    const settings = el.shadowRoot!.querySelector(SETTINGS_TAG)!;
+
+    const ev = new TouchEvent('touchstart', { cancelable: true, touches: [{ clientY: 50 }] } as any);
+    const prevent = jest.spyOn(ev, 'preventDefault');
+    settings.dispatchEvent(ev);
+    expect(prevent).toHaveBeenCalled();
   });
 });

--- a/webcomponents/src/components/rsvp-settings.ts
+++ b/webcomponents/src/components/rsvp-settings.ts
@@ -19,6 +19,7 @@ export class RsvpSettings extends LitElement {
       padding: 20px;
       z-index: 10;
       overflow-y: auto;
+      overscroll-behavior: contain;
     }
 
     @media (max-width: 600px) {
@@ -124,6 +125,75 @@ export class RsvpSettings extends LitElement {
 
   private _onClose() {
     this.dispatchEvent(new CustomEvent('close'));
+  }
+
+  private _touchStartY = 0;
+
+  private _onPointerDown = (e: PointerEvent) => {
+    if (e.pointerType === 'touch') {
+      this._touchStartY = e.clientY;
+      e.preventDefault();
+    }
+  };
+
+  private _onPointerMove = (e: PointerEvent) => {
+    if (e.pointerType === 'touch') {
+      e.preventDefault();
+    }
+  };
+
+  private _onPointerUp = (e: PointerEvent) => {
+    if (e.pointerType === 'touch') {
+      const deltaY = e.clientY - this._touchStartY;
+      e.preventDefault();
+      if (deltaY > 50) {
+        this._onClose();
+      }
+    }
+  };
+
+  private _onTouchStart = (e: TouchEvent) => {
+    const touch = e.touches[0] ?? e.changedTouches[0];
+    if (touch) {
+      this._touchStartY = touch.clientY;
+      e.preventDefault();
+    }
+  };
+
+  private _onTouchMove = (e: TouchEvent) => {
+    e.preventDefault();
+  };
+
+  private _onTouchEnd = (e: TouchEvent) => {
+    const touch = e.changedTouches[0] ?? e.touches[0];
+    if (!touch) {
+      return;
+    }
+    const deltaY = touch.clientY - this._touchStartY;
+    e.preventDefault();
+    if (deltaY > 50) {
+      this._onClose();
+    }
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('pointerdown', this._onPointerDown);
+    this.addEventListener('pointermove', this._onPointerMove);
+    this.addEventListener('pointerup', this._onPointerUp);
+    this.addEventListener('touchstart', this._onTouchStart, { passive: false });
+    this.addEventListener('touchmove', this._onTouchMove, { passive: false });
+    this.addEventListener('touchend', this._onTouchEnd, { passive: false });
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener('pointerdown', this._onPointerDown);
+    this.removeEventListener('pointermove', this._onPointerMove);
+    this.removeEventListener('pointerup', this._onPointerUp);
+    this.removeEventListener('touchstart', this._onTouchStart);
+    this.removeEventListener('touchmove', this._onTouchMove);
+    this.removeEventListener('touchend', this._onTouchEnd);
   }
 
   render() {


### PR DESCRIPTION
## Summary
- prevent pull-to-refresh while swiping the settings pane
- close settings pane on downward swipe without refreshing
- test that default action is prevented during swipe
- **now:** block browser pull-to-refresh via overscroll-behavior and PWA manifest

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ee959418c8331ab2ae1f6e2426fdd