### PR TITLE
Add replay state to speed reader

### DIFF
--- a/docs/design/decisions/0002-replay-button.md
+++ b/docs/design/decisions/0002-replay-button.md
@@ -1,0 +1,10 @@
+# Decision: Add Replay State
+
+## Context
+User feedback indicated confusion when playback stopped at the end of a session. The play button continued to display the play icon even though pressing it restarted the text.
+
+## Decision
+Introduce a distinct `Replay` state in the controls. When the last word has been displayed and playback has stopped, the play/pause control now shows a replay icon and `aria-label` of `Replay`. Pressing this button resets the session to the beginning and resumes playback, after which the control returns to the standard play/pause behaviour.
+
+## Consequences
+This clarifies that the session has finished and improves usability on both desktop and mobile. The change required exposing an `isEnded` property on the `rsvp-controls` component and updating tests.

--- a/webcomponents/src/components/rsvp-controls.ts
+++ b/webcomponents/src/components/rsvp-controls.ts
@@ -8,11 +8,13 @@ export class RsvpControls extends LitElement {
         playing: { type: Boolean },
         wpm: { type: Number },
         isFullscreen: { type: Boolean },
+        isEnded: { type: Boolean },
     };
 
     @property({ type: Boolean }) playing: boolean = false;
     @property({ type: Number }) wpm: number = 300;
     @property({ type: Boolean }) isFullscreen: boolean = false;
+    @property({ type: Boolean }) isEnded: boolean = false;
 
     static styles = css`
         .controls {
@@ -89,10 +91,17 @@ export class RsvpControls extends LitElement {
     };
 
     render() {
-        const playPauseIcon = this.playing
-            ? html`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>`
-            : html`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>`;
-        const playPauseLabel = this.playing ? 'Pause' : 'Play';
+        let playPauseIcon;
+        let playPauseLabel = 'Play';
+        if (this.isEnded) {
+            playPauseIcon = html`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12 5V1L7 6l5 5V7c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.14-7-7h2c0 2.76 2.24 5 5 5s5-2.24 5-5-2.24-5-5-5z"/></svg>`;
+            playPauseLabel = 'Replay';
+        } else if (this.playing) {
+            playPauseIcon = html`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>`;
+            playPauseLabel = 'Pause';
+        } else {
+            playPauseIcon = html`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>`;
+        }
         return html`
       <div class="controls">
         <div class="control-group">

--- a/webcomponents/src/components/rsvp-replay.test.ts
+++ b/webcomponents/src/components/rsvp-replay.test.ts
@@ -1,0 +1,40 @@
+import '@testing-library/jest-dom';
+import { fireEvent } from '@testing-library/dom';
+import { jest } from '@jest/globals';
+import { RsvpPlayer } from './rsvp-player';
+
+const TAG = 'rsvp-player';
+
+if (!customElements.get(TAG)) {
+  customElements.define(TAG, RsvpPlayer);
+}
+
+describe('RsvpPlayer replay control', () => {
+  it('switches to replay at end and back to play/pause after press', async () => {
+    jest.useFakeTimers();
+    document.body.innerHTML = `<${TAG} text="one two"></${TAG}>`;
+    const el = document.querySelector<RsvpPlayer>(TAG)!;
+    await el.updateComplete;
+    const controls = el.shadowRoot!.querySelector('rsvp-controls')!;
+    await (controls as any).updateComplete;
+    const button = controls.shadowRoot!.querySelector('button') as HTMLButtonElement;
+
+    // start playback
+    fireEvent.click(button);
+    await el.updateComplete;
+
+    const interval = 60000 / el.wpm;
+    jest.advanceTimersByTime(interval * el.text.split(/\s+/).length);
+    await el.updateComplete;
+    await (controls as any).updateComplete;
+
+    expect(button.getAttribute('aria-label')).toBe('Replay');
+
+    // press replay
+    fireEvent.click(button);
+    await el.updateComplete;
+    await (controls as any).updateComplete;
+    expect(button.getAttribute('aria-label')).toBe('Pause');
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- show Replay icon when the text finishes
- add tests for replay behaviour
- document design decision

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fad7dbb5c8331bceaf30d393dd5a7