### PR TITLE
Make settings textarea read-only when URL set

### DIFF
--- a/webcomponents/src/components/rsvp-settings.test.ts
+++ b/webcomponents/src/components/rsvp-settings.test.ts
@@ -5,6 +5,7 @@ import './rsvp-settings';
 import type { RsvpSettings } from './rsvp-settings';
 
 const TAG = 'rsvp-settings';
+const TEST_URL = 'http://example.com';
 
 describe('RsvpSettings', () => {
   beforeEach(() => {
@@ -34,7 +35,7 @@ describe('RsvpSettings', () => {
       text: async () => '<html><body>Hello World</body></html>'
     }));
     (global as any).fetch = fetchMock;
-    el.url = 'http://example.com';
+    el.url = TEST_URL;
     await el.updateComplete;
     const loadButton = el.shadowRoot!.querySelector('.load-url') as HTMLButtonElement;
     const listener = jest.fn();
@@ -42,7 +43,15 @@ describe('RsvpSettings', () => {
     fireEvent.click(loadButton);
     await Promise.resolve();
     await Promise.resolve();
-    expect(fetchMock).toHaveBeenCalledWith('http://example.com');
+    expect(fetchMock).toHaveBeenCalledWith(TEST_URL);
     expect(listener).toHaveBeenCalledWith(expect.objectContaining({ detail: 'Hello World' }));
+  });
+
+  it('disables textarea when url is set', async () => {
+    const el = document.querySelector(TAG) as RsvpSettings;
+    el.url = TEST_URL;
+    await el.updateComplete;
+    const textarea = el.shadowRoot!.querySelector('textarea') as HTMLTextAreaElement;
+    expect(textarea).toHaveAttribute('readonly');
   });
 });

--- a/webcomponents/src/components/rsvp-settings.ts
+++ b/webcomponents/src/components/rsvp-settings.ts
@@ -218,7 +218,13 @@ export class RsvpSettings extends LitElement {
         ${pasteActive ? html`
           <div>
             <label for="text-input">Text to Display:</label>
-            <textarea id="text-input" .value=${this.text} @input=${this._onTextInput}></textarea>
+            <textarea
+              id="text-input"
+              .value=${this.text}
+              @input=${this._onTextInput}
+              ?readonly=${this.url !== ''}
+              aria-readonly=${this.url !== ''}
+            ></textarea>
           </div>
         ` : html`
           <div>


### PR DESCRIPTION
## Summary
- disable editing of settings textarea when a URL is provided
- check for the readonly attribute in settings tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fae6c98548331b2f7ae6fa602d731