### PR TITLE
Add missing tests for controls and settings

### DIFF
--- a/webcomponents/src/components/rsvp-controls.test.ts
+++ b/webcomponents/src/components/rsvp-controls.test.ts
@@ -1,0 +1,57 @@
+import '@testing-library/jest-dom';
+import { fireEvent } from '@testing-library/dom';
+import './rsvp-controls';
+import { jest } from "@jest/globals";
+import { RsvpControls } from './rsvp-controls';
+
+describe('RsvpControls', () => {
+  const TAG = 'rsvp-controls';
+
+  beforeEach(() => {
+    if (!customElements.get(TAG)) {
+      customElements.define(TAG, RsvpControls);
+    }
+    document.body.innerHTML = `<${TAG}></${TAG}>`;
+  });
+
+  it('dispatches events on button click', async () => {
+    const el = document.querySelector(TAG) as RsvpControls;
+    await el.updateComplete;
+    const events: Array<[string, string]> = [
+      ['play-pause', el.playing ? 'Pause' : 'Play'],
+      ['rewind', 'Rewind'],
+      ['fast-forward', 'Fast Forward'],
+      ['decrease-speed', 'Decrease speed'],
+      ['increase-speed', 'Increase speed'],
+      ['toggle-fullscreen', 'Toggle Fullscreen'],
+      ['toggle-settings', 'Settings'],
+    ];
+
+    for (const [eventName, label] of events) {
+      const button = el.shadowRoot!.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`)!;
+      const listener = jest.fn();
+      el.addEventListener(eventName, listener);
+      fireEvent.click(button);
+      expect(listener).toHaveBeenCalled();
+      el.removeEventListener(eventName, listener);
+    }
+  });
+
+  it('updates play/pause label based on state', async () => {
+    const el = document.querySelector(TAG) as RsvpControls;
+    await el.updateComplete;
+    let button = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Play"]')!;
+    expect(button).toBeInTheDocument();
+
+    el.playing = true;
+    await el.updateComplete;
+    button = el.shadowRoot!.querySelector<HTMLButtonElement>('button[aria-label="Pause"]')!;
+    expect(button).toBeInTheDocument();
+  });
+
+  it('includes mobile styles', () => {
+    const css = Array.isArray(RsvpControls.styles) ? RsvpControls.styles.map(s => s.cssText).join('') : RsvpControls.styles.cssText;
+    expect(css).toMatch(/@media\s*\(max-width: 600px\)/);
+    expect(css).toMatch(/flex-wrap:\s*wrap/);
+  });
+});

--- a/webcomponents/src/components/rsvp-settings.test.ts
+++ b/webcomponents/src/components/rsvp-settings.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function, sonarjs/no-duplicate-string */
 import '@testing-library/jest-dom';
 import { fireEvent } from '@testing-library/dom';
 import { jest } from '@jest/globals';
@@ -44,5 +45,34 @@ describe('RsvpSettings', () => {
     await Promise.resolve();
     expect(fetchMock).toHaveBeenCalledWith('http://example.com');
     expect(listener).toHaveBeenCalledWith(expect.objectContaining({ detail: 'Hello World' }));
+  });
+
+  it('emits close event when _onClose called', () => {
+    const el = document.querySelector(TAG) as RsvpSettings;
+    const listener = jest.fn();
+    el.addEventListener('close', listener);
+    (el as any)._onClose();
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it('emits close event on simulated swipe down', async () => {
+    const el = document.querySelector(TAG) as RsvpSettings;
+    await el.updateComplete;
+    (el as any)._touchStartY = 100;
+    const listener = jest.fn();
+    el.addEventListener('close', listener);
+    (el as any)._onPointerUp({ pointerType: 'touch', clientY: 170, preventDefault() {} } as PointerEvent);
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it('updates aria-selected on tab change', async () => {
+    const el = document.querySelector(TAG) as RsvpSettings;
+    await el.updateComplete;
+    const tabs = el.shadowRoot!.querySelectorAll('nav[role="tablist"] button');
+    expect(tabs[0]!.getAttribute('aria-selected')).toBe('true');
+    fireEvent.click(tabs[1]!);
+    await el.updateComplete;
+    expect(tabs[0]!.getAttribute('aria-selected')).toBe('false');
+    expect(tabs[1]!.getAttribute('aria-selected')).toBe('true');
   });
 });


### PR DESCRIPTION
## Summary
- add new tests for `rsvp-controls` events, state changes and mobile styles
- extend `rsvp-settings` tests to cover close events and accessibility

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685faed8a4a483319636aa08ddec6a8e