### PR TITLE
Add nested punctuation scoping

### DIFF
--- a/webcomponents/src/components/rsvp-player.scopes.test.ts
+++ b/webcomponents/src/components/rsvp-player.scopes.test.ts
@@ -1,0 +1,32 @@
+import '@testing-library/jest-dom';
+import { RsvpPlayer } from './rsvp-player';
+
+const TAG = 'rsvp-player';
+
+if (!customElements.get(TAG)) {
+  customElements.define(TAG, RsvpPlayer);
+}
+
+describe('RsvpPlayer punctuation scopes', () => {
+  const TEXT = 'I like eggs (I like the shape of them - as geometry is my "raison detre")';
+
+  beforeEach(() => {
+    document.body.innerHTML = `<${TAG}></${TAG}>`;
+  });
+
+  it('renders nested punctuation scopes', async () => {
+    const el = document.querySelector<RsvpPlayer>(TAG)!;
+    el.text = TEXT;
+    await el.updateComplete;
+
+    (el as any).index = 6; // word "shape"
+    await el.updateComplete;
+    let wordEl = el.shadowRoot!.querySelector('.word') as HTMLElement;
+    expect(wordEl).toHaveTextContent('(shape)');
+
+    (el as any).index = 14; // word "raison"
+    await el.updateComplete;
+    wordEl = el.shadowRoot!.querySelector('.word') as HTMLElement;
+    expect(wordEl).toHaveTextContent('("raison")');
+  });
+});


### PR DESCRIPTION
## Summary
- parse text into tokens with punctuation scope info
- render words using nested punctuation scope
- test nested punctuation rendering

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fb0eacb888331ae8e12c6d147cccf