### PR TITLE
Add punctuation parsing and markers

### DIFF
--- a/docs/design/components/rsvp-player.md
+++ b/docs/design/components/rsvp-player.md
@@ -4,6 +4,7 @@
 - Root (`<sr-rsvp-player>`)
 - Word Display (`.word`)
 - Punctuation Markers (`.punctuation`)
+- [Punctuation Rules](../punctuation-rules.md)
 - Controls Slot (`slot[name=controls]`)
 - Progress Bar (`.progress`)
 - Settings Pane (`sr-rsvp-settings`)

--- a/docs/design/punctuation-rules.md
+++ b/docs/design/punctuation-rules.md
@@ -1,0 +1,17 @@
+# Punctuation Rendering Rules
+
+The RSVP player handles punctuation to preserve reading rhythm while signalling sentence boundaries.
+
+- **Sentence markers**
+  - A sentence ending with `?` displays a question mark below every word in that sentence.
+  - A sentence ending with `!` shows an exclamation mark below every word.
+  - If a sentence ends with both (`?!` or `!?`), both symbols appear beneath each word.
+- **Ellipses**
+  - An ellipsis (`...`) is rendered as a sequence of three words: `.` then `..` then `...`.
+  - Each period remains onscreen until the full ellipsis is shown, using the current WPM delay for each step.
+- **Commas**
+  - Commas do not appear onscreen but cause the preceding word to stay for one extra delay interval.
+- **Periods**
+  - A period that ends a sentence does not display and has no extra delay.
+
+These rules ensure visual cues for questioning or emphatic sentences while keeping pacing consistent.

--- a/webcomponents/src/components/rsvp-punctuation.test.ts
+++ b/webcomponents/src/components/rsvp-punctuation.test.ts
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom';
+import { parseText } from './rsvp-player';
+
+describe('parseText punctuation rules', () => {
+  it('assigns question marker to sentence words', () => {
+    const tokens = parseText('Hello world?');
+    expect(tokens[0].markers).toEqual(['?']);
+    expect(tokens[1].markers).toEqual(['?']);
+  });
+
+  it('handles combined markers', () => {
+    const tokens = parseText('Really?!');
+    expect(tokens[0].markers.sort()).toEqual(['!', '?']);
+  });
+
+  it('creates incremental ellipsis tokens', () => {
+    const tokens = parseText('Wait...');
+    expect(tokens.map(t => t.text)).toEqual(['Wait', '.', '..', '...']);
+  });
+
+  it('adds pause after comma', () => {
+    const tokens = parseText('Hello, world');
+    expect(tokens[0].extraPause).toBe(1);
+    expect(tokens[1].extraPause).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- parse punctuation markers in the text parser
- display subtext punctuation under each word
- add punctuation handling unit tests
- document punctuation rules

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fc18429a88331973867df47dff509