### PR TITLE
Improve mobile settings pane

### DIFF
--- a/webcomponents/src/components/rsvp-settings-pane.test.ts
+++ b/webcomponents/src/components/rsvp-settings-pane.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import '@testing-library/jest-dom';
 import { fireEvent } from '@testing-library/dom';
 import { jest } from '@jest/globals';
@@ -29,6 +30,23 @@ describe('RsvpPlayer settings pane', () => {
     fireEvent.click(button);
     await el.updateComplete;
     expect(el.shadowRoot!.querySelector(SETTINGS_TAG)).toBeInTheDocument();
+  });
+
+  it('closes settings pane when close button clicked', async () => {
+    document.body.innerHTML = TEMPLATE;
+    const el = document.querySelector(PLAYER_TAG)! as RsvpPlayer;
+    await el.updateComplete;
+
+    const controls = el.shadowRoot!.querySelector(CONTROLS_TAG)!;
+    await (controls as any).updateComplete;
+    const open = controls.shadowRoot!.querySelector(SETTINGS_BUTTON_SELECTOR)!;
+    fireEvent.click(open);
+    await el.updateComplete;
+    const settings = el.shadowRoot!.querySelector(SETTINGS_TAG)!;
+    const close = settings.shadowRoot!.querySelector('.close-button') as HTMLButtonElement;
+    fireEvent.click(close);
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector(SETTINGS_TAG)).not.toBeInTheDocument();
   });
 
   it('shows settings pane on swipe up gesture', async () => {
@@ -82,9 +100,12 @@ describe('RsvpPlayer settings pane', () => {
     await el.updateComplete;
     const settings = el.shadowRoot!.querySelector(SETTINGS_TAG)!;
 
-    const ev = new TouchEvent('touchstart', { cancelable: true, touches: [{ clientY: 50 }] } as any);
-    const prevent = jest.spyOn(ev, 'preventDefault');
-    settings.dispatchEvent(ev);
+    settings.scrollTop = 0;
+    const start = new TouchEvent('touchstart', { cancelable: true, touches: [{ clientY: 50 }] } as any);
+    settings.dispatchEvent(start);
+    const move = new TouchEvent('touchmove', { cancelable: true, touches: [{ clientY: 70 }] } as any);
+    const prevent = jest.spyOn(move, 'preventDefault');
+    settings.dispatchEvent(move);
     expect(prevent).toHaveBeenCalled();
   });
 });

--- a/webcomponents/src/components/rsvp-settings.test.ts
+++ b/webcomponents/src/components/rsvp-settings.test.ts
@@ -47,11 +47,22 @@ describe('RsvpSettings', () => {
     expect(listener).toHaveBeenCalledWith(expect.objectContaining({ detail: 'Hello World' }));
   });
 
-  it('disables textarea when url is set', async () => {
+  it('hides textarea when in url mode', async () => {
+    const el = document.querySelector(TAG) as RsvpSettings;
+    el.mode = 'url';
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('textarea')).toBeNull();
+    expect(el.shadowRoot!.querySelector('input[type="url"]')).toBeInTheDocument();
+  });
+
+  it('enables textarea after switching back to paste mode', async () => {
     const el = document.querySelector(TAG) as RsvpSettings;
     el.url = TEST_URL;
+    el.mode = 'url';
+    await el.updateComplete;
+    el.mode = 'paste';
     await el.updateComplete;
     const textarea = el.shadowRoot!.querySelector('textarea') as HTMLTextAreaElement;
-    expect(textarea).toHaveAttribute('readonly');
+    expect(textarea).not.toHaveAttribute('readonly');
   });
 });

--- a/webcomponents/src/components/rsvp-settings.ts
+++ b/webcomponents/src/components/rsvp-settings.ts
@@ -143,9 +143,15 @@ export class RsvpSettings extends LitElement {
       color: #FFFFFF;
       font-size: 24px;
       cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50%;
+      transition: background-color 0.2s, color 0.2s;
     }
     .close-button:hover {
-      color: #CCCCCC;
+      background-color: #FFFFFF;
+      color: #000000;
     }
   `;
 
@@ -200,54 +206,62 @@ export class RsvpSettings extends LitElement {
   }
 
   private _touchStartY = 0;
+  private _isSwiping = false;
 
   private _onPointerDown = (e: PointerEvent) => {
     if (e.pointerType === 'touch' && this.gestures.settingsSwipe) {
       this._touchStartY = e.clientY;
-      e.preventDefault();
+      this._isSwiping = this.scrollTop === 0;
     }
   };
 
   private _onPointerMove = (e: PointerEvent) => {
-    if (e.pointerType === 'touch' && this.gestures.settingsSwipe) {
-      e.preventDefault();
+    if (e.pointerType === 'touch' && this.gestures.settingsSwipe && this._isSwiping) {
+      const deltaY = e.clientY - this._touchStartY;
+      if (deltaY > 10) {
+        e.preventDefault();
+      }
     }
   };
 
   private _onPointerUp = (e: PointerEvent) => {
-    if (e.pointerType === 'touch' && this.gestures.settingsSwipe) {
+    if (e.pointerType === 'touch' && this.gestures.settingsSwipe && this._isSwiping) {
       const deltaY = e.clientY - this._touchStartY;
-      e.preventDefault();
       if (deltaY > 50) {
+        e.preventDefault();
         this._onClose();
       }
     }
+    this._isSwiping = false;
   };
 
   private _onTouchStart = (e: TouchEvent) => {
     const touch = e.touches[0] ?? e.changedTouches[0];
     if (touch && this.gestures.settingsSwipe) {
       this._touchStartY = touch.clientY;
-      e.preventDefault();
+      this._isSwiping = this.scrollTop === 0;
     }
   };
 
   private _onTouchMove = (e: TouchEvent) => {
-    if (this.gestures.settingsSwipe) {
-      e.preventDefault();
+    if (this.gestures.settingsSwipe && this._isSwiping) {
+      const touch = e.touches[0] ?? e.changedTouches[0];
+      if (touch && touch.clientY - this._touchStartY > 10) {
+        e.preventDefault();
+      }
     }
   };
 
   private _onTouchEnd = (e: TouchEvent) => {
     const touch = e.changedTouches[0] ?? e.touches[0];
-    if (!touch || !this.gestures.settingsSwipe) {
-      return;
+    if (touch && this.gestures.settingsSwipe && this._isSwiping) {
+      const deltaY = touch.clientY - this._touchStartY;
+      if (deltaY > 50) {
+        e.preventDefault();
+        this._onClose();
+      }
     }
-    const deltaY = touch.clientY - this._touchStartY;
-    e.preventDefault();
-    if (deltaY > 50) {
-      this._onClose();
-    }
+    this._isSwiping = false;
   };
 
   connectedCallback() {
@@ -294,8 +308,8 @@ export class RsvpSettings extends LitElement {
               id="text-input"
               .value=${this.text}
               @input=${this._onTextInput}
-              ?readonly=${this.url !== ''}
-              aria-readonly=${this.url !== ''}
+              ?readonly=${this.mode === 'url'}
+              aria-readonly=${this.mode === 'url'}
             ></textarea>
           </div>
         ` : html`


### PR DESCRIPTION
## Summary
- tweak mobile gesture logic to allow scrolling the settings pane
- style close button with transparent background and hover inversion
- keep textarea editable when switching modes
- add regression tests for new behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fc7e134a0833183541433d2ba760c