### PR TITLE
Add extensible parser system

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Speed-Reader is a cross-platform reading tool that presents text one word at a t
 - Settings pane for text input, URL loading and font size
 - Fullscreen toggle
 - Configurable keybindings and gestures ([defaults](features/default_keybindings.md))
+- Modular content parsers with HTML and text implementations
 
 ## 4. Planned Features
 1. **Configurable Control** ([feature](features/configurable_control.feature))

--- a/webcomponents/src/components/rsvp-player.ts
+++ b/webcomponents/src/components/rsvp-player.ts
@@ -3,13 +3,7 @@ import { property, state } from 'lit/decorators.js';
 import './rsvp-settings';
 import './rsvp-controls';
 import './rsvp-fullscreen';
-
-export interface Token {
-  text: string;
-  scopes: string[];
-  markers: string[];
-  extraPause: number;
-}
+import { Token, parseText } from '../parsers/tokenizer';
 
 interface Keybindings {
   playPause: string;
@@ -25,117 +19,6 @@ interface GestureSettings {
   settingsSwipe: boolean;
 }
 
-const OPENERS = ['(', '[', '{', '"', "'"] as const;
-const CLOSERS: Record<string, string> = {
-  ')': '(',
-  ']': '[',
-  '}': '{',
-  '"': '"',
-  "'": "'",
-};
-
-/* eslint-disable max-lines-per-function, sonarjs/cognitive-complexity, complexity */
-export function parseText(text: string): Token[] {
-  const tokens: Token[] = [];
-  const stack: string[] = [];
-  let word = '';
-  let sentenceIndices: number[] = [];
-
-  const pushWord = () => {
-    if (word) {
-      tokens.push({ text: word, scopes: [...stack], markers: [], extraPause: 0 });
-      sentenceIndices.push(tokens.length - 1);
-      word = '';
-    }
-  };
-
-  for (let i = 0; i < text.length;) {
-    const ch = text[i];
-
-    if (text.slice(i, i + 3) === '...') {
-      pushWord();
-      for (let j = 1; j <= 3; j++) {
-        tokens.push({ text: '.'.repeat(j), scopes: [...stack], markers: [], extraPause: 0 });
-        sentenceIndices.push(tokens.length - 1);
-      }
-      i += 3;
-      continue;
-    }
-
-    if ((OPENERS as readonly string[]).includes(ch)) {
-      pushWord();
-      stack.push(ch);
-      i++;
-      continue;
-    }
-
-    if (Object.prototype.hasOwnProperty.call(CLOSERS, ch)) {
-      pushWord();
-      if (stack.at(-1) === CLOSERS[ch]) {
-        stack.pop();
-      }
-      i++;
-      continue;
-    }
-
-    if (/\s/.test(ch)) {
-      pushWord();
-      i++;
-      continue;
-    }
-
-    if (ch === ',') {
-      pushWord();
-      if (tokens.length > 0) {
-        const last = tokens.at(-1)!;
-        last.extraPause += 1;
-      }
-      i++;
-      continue;
-    }
-
-    if (ch === ':' || ch === ';') {
-      pushWord();
-      if (tokens.length > 0) {
-        const last = tokens.at(-1)!;
-        last.extraPause += 1;
-      }
-      i++;
-      continue;
-    }
-
-    if (ch === '.' || ch === '!' || ch === '?') {
-      pushWord();
-      let j = i;
-      const markers: string[] = [];
-      while (j < text.length) {
-        if (text.slice(j, j + 3) === '...') {
-          break;
-        }
-        const c = text[j];
-        if (c === '!' || c === '?') {
-          markers.push(c);
-        } else if (c !== '.') {
-          break;
-        }
-        j++;
-      }
-      const dedup = [...new Set(markers)];
-      for (const idx of sentenceIndices) {
-        tokens[idx].markers = dedup;
-      }
-      sentenceIndices = [];
-      i = j;
-      continue;
-    }
-
-    word += ch;
-    i++;
-  }
-  pushWord();
-  return tokens;
-}
-/* eslint-enable max-lines-per-function, sonarjs/cognitive-complexity */
 
 function formatToken(token: Token): string {
   const closingMap: Record<string, string> = {

--- a/webcomponents/src/components/rsvp-punctuation.test.ts
+++ b/webcomponents/src/components/rsvp-punctuation.test.ts
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { parseText } from './rsvp-player';
+import { parseText } from '../parsers/tokenizer';
 
 describe('parseText punctuation rules', () => {
   it('assigns question marker to sentence words', () => {

--- a/webcomponents/src/components/rsvp-settings.ts
+++ b/webcomponents/src/components/rsvp-settings.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import { property } from 'lit/decorators.js';
+import { HtmlParser } from '../parsers/content-parser';
 
 interface Keybindings {
   playPause: string;
@@ -177,10 +178,10 @@ export class RsvpSettings extends LitElement {
     try {
       const res = await fetch(this.url);
       const text = await res.text();
-      const doc = new DOMParser().parseFromString(text, 'text/html');
-      const bodyText = doc.body.textContent ?? '';
+      const parser = new HtmlParser();
+      const parsed = parser.parse(text);
       this.dispatchEvent(
-        new CustomEvent('text-change', { detail: bodyText.trim() })
+        new CustomEvent('text-change', { detail: parsed })
       );
     } catch {
       // Swallow network errors

--- a/webcomponents/src/parsers/content-parser.ts
+++ b/webcomponents/src/parsers/content-parser.ts
@@ -1,0 +1,52 @@
+export interface ContentParser {
+  parse(content: string): string;
+}
+
+/**
+ * Pass-through parser for plain text input.
+ */
+export class TextParser implements ContentParser {
+  parse(content: string): string {
+    return content;
+  }
+}
+
+/**
+ * Simple HTML parser that extracts visible text content from an HTML document.
+ * It removes script, style and other non-content elements before gathering
+ * text from the <article> element if present, falling back to <body>.
+ */
+export class HtmlParser implements ContentParser {
+  parse(content: string): string {
+    const doc = new DOMParser().parseFromString(content, 'text/html');
+
+    for (const el of doc.querySelectorAll('script,style,noscript,template,head')) {
+      el.remove();
+    }
+
+    const container = doc.querySelector('article') ?? doc.body;
+    if (!container) {
+      return '';
+    }
+    const walker = doc.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+    let text = '';
+    while (walker.nextNode()) {
+      const value = walker.currentNode.nodeValue?.trim() ?? '';
+      if (value) {
+        text += `${value} `;
+      }
+    }
+    return text.replaceAll(/\s+/g, ' ').trim();
+  }
+}
+
+export function getParser(type: string): ContentParser {
+  switch (type) {
+    case 'html':
+      return new HtmlParser();
+    case 'text':
+      return new TextParser();
+    default:
+      return new TextParser();
+  }
+}

--- a/webcomponents/src/parsers/html-parser.test.ts
+++ b/webcomponents/src/parsers/html-parser.test.ts
@@ -1,0 +1,11 @@
+import { HtmlParser } from './content-parser';
+
+describe('HtmlParser', () => {
+  it('extracts visible text from html', () => {
+    const html = `<!DOCTYPE html>
+      <html><head><style>.a{}</style><script>1</script></head>
+      <body><article><h1>Hello</h1><!--comment--><p>World &amp; <b>friends</b></p></article></body></html>`;
+    const parser = new HtmlParser();
+    expect(parser.parse(html)).toBe('Hello World & friends');
+  });
+});

--- a/webcomponents/src/parsers/text-parser.test.ts
+++ b/webcomponents/src/parsers/text-parser.test.ts
@@ -1,0 +1,8 @@
+import { TextParser } from './content-parser';
+
+describe('TextParser', () => {
+  it('returns the text unchanged', () => {
+    const parser = new TextParser();
+    expect(parser.parse('Hello world')).toBe('Hello world');
+  });
+});

--- a/webcomponents/src/parsers/tokenizer.ts
+++ b/webcomponents/src/parsers/tokenizer.ts
@@ -1,0 +1,118 @@
+export interface Token {
+  text: string;
+  scopes: string[];
+  markers: string[];
+  extraPause: number;
+}
+
+const OPENERS = ['(', '[', '{', '"', "'"] as const;
+const CLOSERS: Record<string, string> = {
+  ')': '(',
+  ']': '[',
+  '}': '{',
+  '"': '"',
+  "'": "'",
+};
+
+/* eslint-disable max-lines-per-function, sonarjs/cognitive-complexity, complexity */
+export function parseText(text: string): Token[] {
+  const tokens: Token[] = [];
+  const stack: string[] = [];
+  let word = '';
+  let sentenceIndices: number[] = [];
+
+  const pushWord = () => {
+    if (word) {
+      tokens.push({ text: word, scopes: [...stack], markers: [], extraPause: 0 });
+      sentenceIndices.push(tokens.length - 1);
+      word = '';
+    }
+  };
+
+  for (let i = 0; i < text.length;) {
+    const ch = text[i];
+
+    if (text.slice(i, i + 3) === '...') {
+      pushWord();
+      for (let j = 1; j <= 3; j++) {
+        tokens.push({ text: '.'.repeat(j), scopes: [...stack], markers: [], extraPause: 0 });
+        sentenceIndices.push(tokens.length - 1);
+      }
+      i += 3;
+      continue;
+    }
+
+    if ((OPENERS as readonly string[]).includes(ch)) {
+      pushWord();
+      stack.push(ch);
+      i++;
+      continue;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(CLOSERS, ch)) {
+      pushWord();
+      if (stack.at(-1) === CLOSERS[ch]) {
+        stack.pop();
+      }
+      i++;
+      continue;
+    }
+
+    if (/\s/.test(ch)) {
+      pushWord();
+      i++;
+      continue;
+    }
+
+    if (ch === ',') {
+      pushWord();
+      if (tokens.length > 0) {
+        const last = tokens.at(-1)!;
+        last.extraPause += 1;
+      }
+      i++;
+      continue;
+    }
+
+    if (ch === ':' || ch === ';') {
+      pushWord();
+      if (tokens.length > 0) {
+        const last = tokens.at(-1)!;
+        last.extraPause += 1;
+      }
+      i++;
+      continue;
+    }
+
+    if (ch === '.' || ch === '!' || ch === '?') {
+      pushWord();
+      let j = i;
+      const markers: string[] = [];
+      while (j < text.length) {
+        if (text.slice(j, j + 3) === '...') {
+          break;
+        }
+        const c = text[j];
+        if (c === '!' || c === '?') {
+          markers.push(c);
+        } else if (c !== '.') {
+          break;
+        }
+        j++;
+      }
+      const dedup = [...new Set(markers)];
+      for (const idx of sentenceIndices) {
+        tokens[idx].markers = dedup;
+      }
+      sentenceIndices = [];
+      i = j;
+      continue;
+    }
+
+    word += ch;
+    i++;
+  }
+  pushWord();
+  return tokens;
+}
+/* eslint-enable max-lines-per-function, sonarjs/cognitive-complexity */


### PR DESCRIPTION
## Summary
- refactor tokenizer to its own module
- create `HtmlParser` and `TextParser` utilities
- use new HTML parser when loading URLs
- test HTML and text parsers
- document new modular parser approach

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fcc81f57083319f05532ff3a0e59d