### PR TITLE
Add file import to settings pane

### DIFF
--- a/webcomponents/src/components/rsvp-settings.test.ts
+++ b/webcomponents/src/components/rsvp-settings.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import '@testing-library/jest-dom';
 import { fireEvent } from '@testing-library/dom';
 import { jest } from '@jest/globals';
@@ -64,5 +65,27 @@ describe('RsvpSettings', () => {
     await el.updateComplete;
     const textarea = el.shadowRoot!.querySelector('textarea') as HTMLTextAreaElement;
     expect(textarea).not.toHaveAttribute('readonly');
+  });
+
+  it('imports text from file', async () => {
+    const el = document.querySelector(TAG) as RsvpSettings;
+    await el.updateComplete;
+    const input = el.shadowRoot!.querySelector('input[type="file"]') as HTMLInputElement;
+    const listener = jest.fn();
+    el.addEventListener('text-change', listener);
+    const file = new File(['<p>Hello File</p>'], 'sample.html', { type: 'text/html' });
+
+    const mockReader: any = {
+      result: '<p>Hello File</p>',
+      addEventListener(_: string, cb: () => void) { cb(); },
+      readAsText() {}
+    };
+    jest.spyOn(window as any, 'FileReader').mockImplementation(() => mockReader);
+    Object.defineProperty(input, 'files', { value: [file] });
+    fireEvent.change(input);
+    await el.updateComplete;
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ detail: 'Hello File' }));
+    const textarea = el.shadowRoot!.querySelector('textarea') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('Hello File');
   });
 });


### PR DESCRIPTION
## Summary
- add TEXT_CHANGE_EVENT constant to avoid duplicate strings
- parse uploaded file in `rsvp-settings` and load into textarea
- expose file input in settings UI
- test file import functionality

## Testing
- `npm run lint --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685fd0e22040833187bc5a038df48670