### PR TITLE
Add session JSON parser and integration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ Speed-Reader is a cross-platform reading tool that presents text one word at a t
 - **Offline:** Workbox Service Worker
 - **NLP/OCR:** Tesseract.js
 - **State:** Redux-style store (Proxy + events)
+- **Playback Format:** [JSON session](architecture/playback-format.md)
 
 ## 7. Milestone 0 (MVP)
 - Lit-based RSVP player (play/pause, speed control)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -8,3 +8,4 @@ This folder contains architecture documentation and C4 models for the Speed-Read
 - [C4 System Context Model](c4-system-context.dsl)
 - [C4 Container Model](c4-container.dsl)
 - [C4 Component Model](c4-component.dsl)
+- [Playback Session Format](playback-format.md)

--- a/docs/architecture/playback-format.md
+++ b/docs/architecture/playback-format.md
@@ -1,0 +1,27 @@
+# Playback Session JSON Format
+
+The RSVP parser outputs a serialized session description that the player consumes for playback.
+The format is designed to capture all timing and punctuation information while remaining extensible.
+
+```json
+{
+  "tokens": [
+    {
+      "text": "Hello",
+      "scopes": [],
+      "markers": [],
+      "delay": 0
+    }
+  ]
+}
+```
+
+- **text** – literal word to display.
+- **scopes** – array of opening punctuation currently in scope. The player
+  renders matching closing characters after the word.
+- **markers** – sentence level punctuation such as `?` or `!` applied to the word.
+- **delay** – additional display intervals beyond the base WPM rate.
+
+Future fields can be added alongside `tokens` without breaking the player. The
+format is parsed from and serialized to JSON using `parseSession` and
+`serializeSession` in `src/parsers/session.ts`.

--- a/webcomponents/src/components/rsvp-player.mobile.test.ts
+++ b/webcomponents/src/components/rsvp-player.mobile.test.ts
@@ -3,6 +3,8 @@ import '@testing-library/jest-dom';
 import { jest } from '@jest/globals';
 import { fireEvent, within } from '@testing-library/dom';
 import { RsvpPlayer } from './rsvp-player';
+import { parseText } from '../parsers/tokenizer';
+import { serializeSession } from '../parsers/session';
 
 describe('RsvpPlayer mobile layout', () => {
   it('includes mobile fullscreen styles', () => {
@@ -56,7 +58,7 @@ describe('RsvpPlayer mobile layout', () => {
 
     it('rewinds and fast-forwards on swipe', async () => {
       const el = document.querySelector<RsvpPlayer>(TAG)!;
-      el.text = 'one two three four five six seven eight nine ten';
+      el.session = serializeSession(parseText('one two three four five six seven eight nine ten'));
       await el.updateComplete;
       Object.defineProperty(el, 'clientWidth', { configurable: true, value: 100 });
       (el as any).index = 5;
@@ -87,7 +89,7 @@ describe('RsvpPlayer mobile layout', () => {
     it('ignores swipe gestures when disabled', async () => {
       const el = document.querySelector<RsvpPlayer>(TAG)!;
       el.gestures = { ...el.gestures, swipe: false };
-      el.text = 'one two three four five';
+      el.session = serializeSession(parseText('one two three four five'));
       await el.updateComplete;
       const word = el.shadowRoot!.querySelector('.word') as HTMLElement;
       (el as any).index = 2;

--- a/webcomponents/src/components/rsvp-player.scopes.test.ts
+++ b/webcomponents/src/components/rsvp-player.scopes.test.ts
@@ -1,5 +1,7 @@
 import '@testing-library/jest-dom';
 import { RsvpPlayer } from './rsvp-player';
+import { parseText } from '../parsers/tokenizer';
+import { serializeSession } from '../parsers/session';
 
 const TAG = 'rsvp-player';
 
@@ -16,7 +18,7 @@ describe('RsvpPlayer punctuation scopes', () => {
 
   it('renders nested punctuation scopes', async () => {
     const el = document.querySelector<RsvpPlayer>(TAG)!;
-    el.text = TEXT;
+    el.session = serializeSession(parseText(TEXT));
     await el.updateComplete;
 
     (el as any).index = 6; // word "shape"

--- a/webcomponents/src/components/rsvp-player.ts
+++ b/webcomponents/src/components/rsvp-player.ts
@@ -4,6 +4,7 @@ import './rsvp-settings';
 import './rsvp-controls';
 import './rsvp-fullscreen';
 import { Token, parseText } from '../parsers/tokenizer';
+import { parseSession, serializeSession } from '../parsers/session';
 
 interface Keybindings {
   playPause: string;
@@ -40,6 +41,7 @@ export class RsvpPlayer extends LitElement {
   // Expose only external properties; internal state managed via @state
   static properties = {
     text: { type: String },
+    session: { type: String },
     wpm: { type: Number },
     wordFontSize: { type: Number }, // Added for word font size configuration
     playing: { type: Boolean },
@@ -51,6 +53,8 @@ export class RsvpPlayer extends LitElement {
   };
   /** Input text for RSVP session */
   @property({ type: String }) text!: string;
+  /** Serialized session json */
+  @property({ type: String }) session: string = '';
   /** Words per minute speed */
   @property({ type: Number }) wpm!: number;
   /** Word font size in rem */
@@ -396,6 +400,9 @@ export class RsvpPlayer extends LitElement {
     if (this.text === undefined) {
       this.text = '';
     }
+    if (this.session === undefined) {
+      this.session = '';
+    }
     if (this.wpm === undefined) {
       this.wpm = 300;
     }
@@ -419,7 +426,7 @@ export class RsvpPlayer extends LitElement {
   }
 
   protected updated(changed: Map<string, any>) {
-    if (changed.has('text')) {
+    if (changed.has('text') || changed.has('session')) {
       this._resetSession();
     }
     if (changed.has('playing')) {
@@ -486,7 +493,11 @@ export class RsvpPlayer extends LitElement {
   }
 
   private _resetSession() {
-    this.words = this.text.trim() ? parseText(this.text.trim()) : [];
+    if (this.session) {
+      this.words = parseSession(this.session);
+    } else {
+      this.words = this.text.trim() ? parseText(this.text.trim()) : [];
+    }
     this.index = 0;
   }
 
@@ -530,6 +541,7 @@ export class RsvpPlayer extends LitElement {
   private _onTextInput(e: Event) {
     const target = e.target as HTMLTextAreaElement;
     this.text = target.value;
+    this.session = serializeSession(parseText(this.text));
   }
 
   private _onWpmInput(e: Event) {

--- a/webcomponents/src/components/rsvp-replay.test.ts
+++ b/webcomponents/src/components/rsvp-replay.test.ts
@@ -2,6 +2,8 @@ import '@testing-library/jest-dom';
 import { fireEvent } from '@testing-library/dom';
 import { jest } from '@jest/globals';
 import { RsvpPlayer } from './rsvp-player';
+import { parseText } from '../parsers/tokenizer';
+import { serializeSession } from '../parsers/session';
 
 const TAG = 'rsvp-player';
 
@@ -12,8 +14,10 @@ if (!customElements.get(TAG)) {
 describe('RsvpPlayer replay control', () => {
   it('switches to replay at end and back to play/pause after press', async () => {
     jest.useFakeTimers();
-    document.body.innerHTML = `<${TAG} text="one two"></${TAG}>`;
+    document.body.innerHTML = `<${TAG}></${TAG}>`;
     const el = document.querySelector<RsvpPlayer>(TAG)!;
+    const tokens = parseText('one two');
+    el.session = serializeSession(tokens);
     await el.updateComplete;
     const controls = el.shadowRoot!.querySelector('rsvp-controls')!;
     await (controls as any).updateComplete;
@@ -24,7 +28,7 @@ describe('RsvpPlayer replay control', () => {
     await el.updateComplete;
 
     const interval = 60000 / el.wpm;
-    jest.advanceTimersByTime(interval * el.text.split(/\s+/).length);
+    jest.advanceTimersByTime(interval * tokens.length);
     await el.updateComplete;
     await (controls as any).updateComplete;
 

--- a/webcomponents/src/components/rsvp-settings-pane.test.ts
+++ b/webcomponents/src/components/rsvp-settings-pane.test.ts
@@ -3,13 +3,15 @@ import '@testing-library/jest-dom';
 import { fireEvent } from '@testing-library/dom';
 import { jest } from '@jest/globals';
 import { RsvpPlayer } from './rsvp-player';
+import { parseText } from '../parsers/tokenizer';
+import { serializeSession } from '../parsers/session';
 
 const PLAYER_TAG = 'rsvp-player';
 const SETTINGS_TAG = 'rsvp-settings';
 const CONTROLS_TAG = 'rsvp-controls';
 const SETTINGS_BUTTON_SELECTOR = 'button[aria-label="Settings"]';
 const TEXT = 'hello world';
-const TEMPLATE = `<${PLAYER_TAG} text="${TEXT}"></${PLAYER_TAG}>`;
+const TEMPLATE = `<${PLAYER_TAG}></${PLAYER_TAG}>`;
 if (!customElements.get(PLAYER_TAG)) {
   customElements.define(PLAYER_TAG, RsvpPlayer);
 }
@@ -18,6 +20,7 @@ describe('RsvpPlayer settings pane', () => {
   it('shows settings pane when settings button clicked', async () => {
     document.body.innerHTML = TEMPLATE;
     const el = document.querySelector(PLAYER_TAG)! as RsvpPlayer;
+    el.session = serializeSession(parseText(TEXT));
     await el.updateComplete;
 
     const controls = el.shadowRoot!.querySelector(CONTROLS_TAG)!;
@@ -35,6 +38,7 @@ describe('RsvpPlayer settings pane', () => {
   it('closes settings pane when close button clicked', async () => {
     document.body.innerHTML = TEMPLATE;
     const el = document.querySelector(PLAYER_TAG)! as RsvpPlayer;
+    el.session = serializeSession(parseText(TEXT));
     await el.updateComplete;
 
     const controls = el.shadowRoot!.querySelector(CONTROLS_TAG)!;
@@ -52,6 +56,7 @@ describe('RsvpPlayer settings pane', () => {
   it('shows settings pane on swipe up gesture', async () => {
     document.body.innerHTML = TEMPLATE;
     const el = document.querySelector(PLAYER_TAG)! as RsvpPlayer;
+    el.session = serializeSession(parseText(TEXT));
     await el.updateComplete;
 
     const down = new Event('pointerdown');
@@ -68,6 +73,7 @@ describe('RsvpPlayer settings pane', () => {
   it('closes settings pane on swipe down gesture', async () => {
     document.body.innerHTML = TEMPLATE;
     const el = document.querySelector(PLAYER_TAG)! as RsvpPlayer;
+    el.session = serializeSession(parseText(TEXT));
     await el.updateComplete;
 
     const controls = el.shadowRoot!.querySelector(CONTROLS_TAG)!;
@@ -91,6 +97,7 @@ describe('RsvpPlayer settings pane', () => {
   it('prevents default page refresh when swiping', async () => {
     document.body.innerHTML = TEMPLATE;
     const el = document.querySelector(PLAYER_TAG)! as RsvpPlayer;
+    el.session = serializeSession(parseText(TEXT));
     await el.updateComplete;
 
     const controls = el.shadowRoot!.querySelector(CONTROLS_TAG)!;

--- a/webcomponents/src/parsers/session.test.ts
+++ b/webcomponents/src/parsers/session.test.ts
@@ -1,0 +1,11 @@
+import { parseText } from './tokenizer';
+import { parseSession, serializeSession } from './session';
+
+describe('Session serialization', () => {
+  it('serializes and parses tokens', () => {
+    const tokens = parseText('Hello world?');
+    const json = serializeSession(tokens);
+    const parsed = parseSession(json);
+    expect(parsed).toEqual(tokens);
+  });
+});

--- a/webcomponents/src/parsers/session.ts
+++ b/webcomponents/src/parsers/session.ts
@@ -1,0 +1,44 @@
+export interface SessionToken {
+  text: string;
+  scopes: string[];
+  markers: string[];
+  delay: number;
+}
+
+export interface SessionData {
+  tokens: SessionToken[];
+}
+
+import type { Token } from './tokenizer';
+
+export function tokensToSession(tokens: Token[]): SessionData {
+  return {
+    tokens: tokens.map(t => ({
+      text: t.text,
+      scopes: t.scopes,
+      markers: t.markers,
+      delay: t.extraPause,
+    })),
+  };
+}
+
+export function sessionToTokens(session: SessionData): Token[] {
+  return session.tokens.map(t => ({
+    text: t.text,
+    scopes: t.scopes ?? [],
+    markers: t.markers ?? [],
+    extraPause: t.delay ?? 0,
+  }));
+}
+
+export function serializeSession(tokens: Token[]): string {
+  return JSON.stringify(tokensToSession(tokens));
+}
+
+export function parseSession(json: string): Token[] {
+  if (!json) {
+    return [];
+  }
+  const data = JSON.parse(json) as SessionData;
+  return sessionToTokens(data);
+}


### PR DESCRIPTION
## Summary
- parse tokens into a serialisable JSON session format
- load session JSON in `rsvp-player`
- keep session in sync when editing text
- update unit tests to use the new session API
- document the session JSON format

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fd27cdf7c8331a21c960fe62a432c