### PR TITLE
Add Markdown parsing support

### DIFF
--- a/webcomponents/package.json
+++ b/webcomponents/package.json
@@ -14,11 +14,13 @@
     "lint": "npm run lint:js && npm run lint:css"
   },
   "dependencies": {
-    "lit": "^2.6.1",
     "@spectrum-web-components/icons-workflow": "^1.7.0",
-    "@spectrum-web-components/reactive-controllers": "^1.7.0"
+    "@spectrum-web-components/reactive-controllers": "^1.7.0",
+    "lit": "^2.6.1",
+    "marked": "^9.1.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.42.1",
     "@testing-library/dom": "^8.0.0",
     "@testing-library/jest-dom": "^5.16.0",
     "@testing-library/user-event": "^14.2.0",
@@ -38,7 +40,6 @@
     "tailwindcss": "^3.0.0",
     "ts-jest": "^29.0.0",
     "typescript": "^4.7.0",
-    "vite": "^4.0.0",
-    "@playwright/test": "^1.42.1"
+    "vite": "^4.0.0"
   }
 }

--- a/webcomponents/src/components/rsvp-settings.ts
+++ b/webcomponents/src/components/rsvp-settings.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, css } from 'lit';
 import { property } from 'lit/decorators.js';
-import { HtmlParser, TextParser } from '../parsers/content-parser';
+import { HtmlParser, MarkdownParser, TextParser } from '../parsers/content-parser';
 import { requestSummary, LlmConfig } from '../llm/summary';
 
 const TEXT_CHANGE_EVENT = 'text-change';
@@ -199,7 +199,12 @@ export class RsvpSettings extends LitElement {
     try {
       const res = await fetch(this.url);
       const text = await res.text();
-      const parser = new HtmlParser();
+      const ct = res.headers?.get('content-type') ?? '';
+      const isMarkdown =
+        ct.includes('markdown') ||
+        this.url.toLowerCase().endsWith('.md') ||
+        this.url.toLowerCase().endsWith('.markdown');
+      const parser = isMarkdown ? new MarkdownParser() : new HtmlParser();
       const parsed = parser.parse(text);
       const processed = await this._maybeSummarize(parsed);
       this.dispatchEvent(
@@ -218,7 +223,15 @@ export class RsvpSettings extends LitElement {
     const type = file.type;
     const isHtml =
       type.includes('html') || ext === 'html' || ext === 'htm';
-    const parser = isHtml ? new HtmlParser() : new TextParser();
+    const isMarkdown = type.includes('markdown') || ext === 'md' || ext === 'markdown';
+    let parser: HtmlParser | MarkdownParser | TextParser;
+    if (isHtml) {
+      parser = new HtmlParser();
+    } else if (isMarkdown) {
+      parser = new MarkdownParser();
+    } else {
+      parser = new TextParser();
+    }
     const reader = new FileReader();
     reader.addEventListener('load', () => {
       const content = (reader.result as string) ?? '';

--- a/webcomponents/src/parsers/content-parser.ts
+++ b/webcomponents/src/parsers/content-parser.ts
@@ -11,6 +11,21 @@ export class TextParser implements ContentParser {
   }
 }
 
+import { marked } from 'marked';
+
+/**
+ * Parse markdown by converting it to HTML and then extracting text using the
+ * existing HtmlParser logic. This keeps behaviour consistent across formats.
+ */
+export class MarkdownParser implements ContentParser {
+  private _htmlParser = new HtmlParser();
+
+  parse(content: string): string {
+    const html = marked.parse(content);
+    return this._htmlParser.parse(html);
+  }
+}
+
 /**
  * Simple HTML parser that extracts visible text content from an HTML document.
  * It removes script, style and other non-content elements before gathering
@@ -44,6 +59,9 @@ export function getParser(type: string): ContentParser {
   switch (type) {
     case 'html':
       return new HtmlParser();
+    case 'markdown':
+    case 'md':
+      return new MarkdownParser();
     case 'text':
       return new TextParser();
     default:

--- a/webcomponents/src/parsers/markdown-parser.test.ts
+++ b/webcomponents/src/parsers/markdown-parser.test.ts
@@ -1,0 +1,9 @@
+import { MarkdownParser } from './content-parser';
+
+describe('MarkdownParser', () => {
+  it('extracts text from markdown', () => {
+    const md = '# Hello **World**';
+    const parser = new MarkdownParser();
+    expect(parser.parse(md)).toBe('Hello World');
+  });
+});


### PR DESCRIPTION
## Summary
- parse Markdown by converting to HTML and stripping markup
- detect Markdown files and URLs
- test Markdown parser
- add `marked` dependency

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860f8324e748331a524431b7f7ea783