### PR TITLE
Integrate Spectrum design system

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
   "private": true,
-  "workspaces": ["webcomponents"],
+  "workspaces": [
+    "webcomponents"
+  ],
   "scripts": {
     "test": "cd webcomponents && npm test && cd ..",
     "lint": "cd webcomponents && npm run lint && cd .."
+  },
+  "dependencies": {
+    "@spectrum-web-components/theme": "^1.7.0"
   }
 }

--- a/webcomponents/index.html
+++ b/webcomponents/index.html
@@ -15,7 +15,9 @@
   </style>
 </head>
 <body>
-  <rsvp-player text="Punctuation demo: commas, semicolons; colons: questions? exclamations! ellipses... and (nested &quot;quotes&quot;)."></rsvp-player>
+  <sp-theme theme="spectrum" scale="medium" color="light">
+    <rsvp-player text="Punctuation demo: commas, semicolons; colons: questions? exclamations! ellipses... and (nested &quot;quotes&quot;)."></rsvp-player>
+  </sp-theme>
   <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/webcomponents/package.json
+++ b/webcomponents/package.json
@@ -14,11 +14,14 @@
     "lint": "npm run lint:js && npm run lint:css"
   },
   "dependencies": {
-    "lit": "^2.6.1",
+    "@spectrum-web-components/button": "^1.7.0",
     "@spectrum-web-components/icons-workflow": "^1.7.0",
-    "@spectrum-web-components/reactive-controllers": "^1.7.0"
+    "@spectrum-web-components/reactive-controllers": "^1.7.0",
+    "@spectrum-web-components/theme": "^1.7.0",
+    "lit": "^2.6.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.42.1",
     "@testing-library/dom": "^8.0.0",
     "@testing-library/jest-dom": "^5.16.0",
     "@testing-library/user-event": "^14.2.0",
@@ -38,7 +41,6 @@
     "tailwindcss": "^3.0.0",
     "ts-jest": "^29.0.0",
     "typescript": "^4.7.0",
-    "vite": "^4.0.0",
-    "@playwright/test": "^1.42.1"
+    "vite": "^4.0.0"
   }
 }

--- a/webcomponents/src/components/rsvp-controls.ts
+++ b/webcomponents/src/components/rsvp-controls.ts
@@ -1,5 +1,14 @@
 import { LitElement, html, css } from 'lit';
 import { property } from 'lit/decorators.js';
+import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-play.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-pause.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-replay.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-rewind.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-fast-forward.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-add.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-remove.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-full-screen.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-full-screen-exit.js';
 
@@ -18,43 +27,29 @@ export class RsvpControls extends LitElement {
 
     static styles = css`
         .controls {
-        background-color: rgba(0, 0, 0, 0.8);
-        padding: 10px;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        border-radius: 8px;
-        margin-top: 16px;
-        }
-        .controls button {
-        background-color: transparent;
-        color: #FFFFFF;
-        border: none;
-        padding: 8px 12px;
-        cursor: pointer;
-        font-size: 1rem;
-        border-radius: 4px;
-        }
-        .controls button:hover {
-        color: #CCCCCC;
-        background-color: rgba(255, 255, 255, 0.1);
+            background-color: rgba(0, 0, 0, 0.8);
+            padding: 10px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border-radius: 8px;
+            margin-top: 16px;
         }
         .wpm {
-        color: #FFFFFF;
-        font-size: 14px;
-        margin: 0 10px;
+            color: #FFFFFF;
+            font-size: 14px;
+            margin: 0 10px;
         }
         .control-group {
-        display: flex;
-        align-items: center;
+            display: flex;
+            align-items: center;
         }
-
         @media (max-width: 600px) {
-        .controls {
-            flex-wrap: wrap;
-            justify-content: center;
-            gap: 8px;
-        }
+            .controls {
+                flex-wrap: wrap;
+                justify-content: center;
+                gap: 8px;
+            }
         }
     `;
 
@@ -94,45 +89,43 @@ export class RsvpControls extends LitElement {
         let playPauseIcon;
         let playPauseLabel = 'Play';
         if (this.isEnded) {
-            playPauseIcon = html`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12 5V1L7 6l5 5V7c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.14-7-7h2c0 2.76 2.24 5 5 5s5-2.24 5-5-2.24-5-5-5z"/></svg>`;
+            playPauseIcon = html`<sp-icon-replay></sp-icon-replay>`;
             playPauseLabel = 'Replay';
         } else if (this.playing) {
-            playPauseIcon = html`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>`;
+            playPauseIcon = html`<sp-icon-pause></sp-icon-pause>`;
             playPauseLabel = 'Pause';
         } else {
-            playPauseIcon = html`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>`;
+            playPauseIcon = html`<sp-icon-play></sp-icon-play>`;
         }
         return html`
       <div class="controls">
         <div class="control-group">
-          <button @click=${this._onPlayPause} aria-label=${playPauseLabel}>
+          <sp-button quiet variant="secondary" @click=${this._onPlayPause} aria-label=${playPauseLabel}>
             ${playPauseIcon}
-          </button>
-          <button @click=${this._onRewind} aria-label="Rewind">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M11 18V6l-8.5 6 8.5 6zm.5-6l8.5 6V6l-8.5 6z"/></svg>
-          </button>
-          <button @click=${this._onFastForward} aria-label="Fast Forward">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="m4 18 8.5-6L4 6v12zm9-12v12l8.5-6L13 6z"/></svg>
-          </button>
+          </sp-button>
+          <sp-button quiet variant="secondary" @click=${this._onRewind} aria-label="Rewind">
+            <sp-icon-rewind></sp-icon-rewind>
+          </sp-button>
+          <sp-button quiet variant="secondary" @click=${this._onFastForward} aria-label="Fast Forward">
+            <sp-icon-fast-forward></sp-icon-fast-forward>
+          </sp-button>
         </div>
         <span class="wpm">${this.wpm} WPM</span>
         <div class="control-group">
-          <button @click=${this._onDecreaseSpeed} aria-label="Decrease speed">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M19 13H5v-2h14v2z"/></svg>
-          </button>
-          <button @click=${this._onIncreaseSpeed} aria-label="Increase speed">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>
-          </button>
-          <button @click=${this._onToggleFullscreen} aria-label="Toggle Fullscreen">
+          <sp-button quiet variant="secondary" @click=${this._onDecreaseSpeed} aria-label="Decrease speed">
+            <sp-icon-remove></sp-icon-remove>
+          </sp-button>
+          <sp-button quiet variant="secondary" @click=${this._onIncreaseSpeed} aria-label="Increase speed">
+            <sp-icon-add></sp-icon-add>
+          </sp-button>
+          <sp-button quiet variant="secondary" @click=${this._onToggleFullscreen} aria-label="Toggle Fullscreen">
             ${this.isFullscreen
               ? html`<sp-icon-full-screen-exit></sp-icon-full-screen-exit>`
               : html`<sp-icon-full-screen></sp-icon-full-screen>`}
-          </button>
-          <button @click=${this._onToggleSettings} aria-label="Settings" part="settings-button">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M19.43 12.98c.04-.32.07-.66.07-1s-.03-.68-.07-1l2.11-1.65a.5.5 0 0 0 .12-.62l-2-3.46a.5.5 0 0 0-.6-.22l-2.49 1a7.07 7.07 0 0 0-1.52-.88l-.38-2.65a.5.5 0 0 0-.49-.42h-4.16a.5.5 0 0 0-.49.42l-.38 2.65a6.96 6.96 0 0 0-1.52.88l-2.49-1a.5.5 0 0 0-.6.22l-2 3.46a.5.5 0 0 0 .12.62L4.57 10c-.04.32-.07.66-.07 1s.03.68.07 1l-2.11 1.65a.5.5 0 0 0-.12.62l2 3.46a.5.5 0 0 0 .6.22l2.49-1c.47.39.99.71 1.52.88l.38 2.65c.03.24.25.42.49.42h4.16c.24 0 .46-.18.49-.42l.38-2.65c.53-.2 1.05-.49 1.52-.88l2.49 1a.5.5 0 0 0 .6-.22l2-3.46a.5.5 0 0 0-.12-.62L19.43 12.98zM12 15.5a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7z"/>
-            </svg>
-          </button>
+          </sp-button>
+          <sp-button quiet variant="secondary" @click=${this._onToggleSettings} aria-label="Settings" part="settings-button">
+            <sp-icon-settings></sp-icon-settings>
+          </sp-button>
         </div>
       </div>
     `;

--- a/webcomponents/src/components/rsvp-fullscreen.toggle.test.ts
+++ b/webcomponents/src/components/rsvp-fullscreen.toggle.test.ts
@@ -3,7 +3,7 @@ import { fireEvent } from '@testing-library/dom';
 import { jest } from '@jest/globals';
 import { RsvpPlayer } from './rsvp-player';
 import './rsvp-controls';
-const FS_SELECTOR = 'button[aria-label="Toggle Fullscreen"]';
+const FS_SELECTOR = 'sp-button[aria-label="Toggle Fullscreen"]';
 const CONTROLS_TAG = 'rsvp-controls';
 
 describe('Fullscreen controls', () => {
@@ -21,7 +21,7 @@ describe('Fullscreen controls', () => {
     await el.updateComplete;
     const controls = el.shadowRoot!.querySelector(CONTROLS_TAG) as HTMLElement;
     await (controls as any).updateComplete;
-    const button = controls.shadowRoot!.querySelector(FS_SELECTOR) as HTMLButtonElement;
+    const button = controls.shadowRoot!.querySelector(FS_SELECTOR) as HTMLElement;
     expect(button.querySelector('sp-icon-full-screen')).toBeInTheDocument();
     controls.setAttribute('isfullscreen', 'true');
     (controls as any).isFullscreen = true;
@@ -39,7 +39,7 @@ describe('Fullscreen controls', () => {
     Object.defineProperty(document, 'fullscreenElement', { configurable: true, get: () => el });
     const controls = el.shadowRoot!.querySelector(CONTROLS_TAG) as HTMLElement;
     await (controls as any).updateComplete;
-    const button = controls.shadowRoot!.querySelector(FS_SELECTOR) as HTMLButtonElement;
+    const button = controls.shadowRoot!.querySelector(FS_SELECTOR) as HTMLElement;
     fireEvent.click(button);
     expect(exit).toHaveBeenCalled();
     expect(request).not.toHaveBeenCalled();
@@ -55,7 +55,7 @@ describe('Fullscreen controls', () => {
     Object.defineProperty(document, 'fullscreenElement', { configurable: true, value: null });
     const controls = el.shadowRoot!.querySelector(CONTROLS_TAG) as HTMLElement;
     await (controls as any).updateComplete;
-    const button = controls.shadowRoot!.querySelector(FS_SELECTOR) as HTMLButtonElement;
+    const button = controls.shadowRoot!.querySelector(FS_SELECTOR) as HTMLElement;
     fireEvent.click(button);
     expect(request).toHaveBeenCalled();
     expect(exit).not.toHaveBeenCalled();

--- a/webcomponents/src/components/rsvp-replay.test.ts
+++ b/webcomponents/src/components/rsvp-replay.test.ts
@@ -21,7 +21,7 @@ describe('RsvpPlayer replay control', () => {
     await el.updateComplete;
     const controls = el.shadowRoot!.querySelector('rsvp-controls')!;
     await (controls as any).updateComplete;
-    const button = controls.shadowRoot!.querySelector('button') as HTMLButtonElement;
+    const button = controls.shadowRoot!.querySelector('sp-button') as HTMLElement;
 
     // start playback
     fireEvent.click(button);

--- a/webcomponents/src/components/rsvp-settings-pane.test.ts
+++ b/webcomponents/src/components/rsvp-settings-pane.test.ts
@@ -9,7 +9,7 @@ import { serializeSession } from '../parsers/session';
 const PLAYER_TAG = 'rsvp-player';
 const SETTINGS_TAG = 'rsvp-settings';
 const CONTROLS_TAG = 'rsvp-controls';
-const SETTINGS_BUTTON_SELECTOR = 'button[aria-label="Settings"]';
+const SETTINGS_BUTTON_SELECTOR = 'sp-button[aria-label="Settings"]';
 const TEXT = 'hello world';
 const TEMPLATE = `<${PLAYER_TAG}></${PLAYER_TAG}>`;
 if (!customElements.get(PLAYER_TAG)) {
@@ -25,10 +25,10 @@ describe('RsvpPlayer settings pane', () => {
 
     const controls = el.shadowRoot!.querySelector(CONTROLS_TAG)!;
     await (controls as any).updateComplete;
-    const button = controls.shadowRoot!.querySelector(SETTINGS_BUTTON_SELECTOR) as HTMLButtonElement;
+    const button = controls.shadowRoot!.querySelector(SETTINGS_BUTTON_SELECTOR) as HTMLElement;
     expect(button).toBeVisible();
     expect(button.getAttribute('part')).toBe('settings-button');
-    const icon = button.querySelector('svg');
+    const icon = button.querySelector('sp-icon-settings');
     expect(icon).toBeTruthy();
     fireEvent.click(button);
     await el.updateComplete;
@@ -43,11 +43,11 @@ describe('RsvpPlayer settings pane', () => {
 
     const controls = el.shadowRoot!.querySelector(CONTROLS_TAG)!;
     await (controls as any).updateComplete;
-    const open = controls.shadowRoot!.querySelector(SETTINGS_BUTTON_SELECTOR)!;
+    const open = controls.shadowRoot!.querySelector(SETTINGS_BUTTON_SELECTOR)! as HTMLElement;
     fireEvent.click(open);
     await el.updateComplete;
     const settings = el.shadowRoot!.querySelector(SETTINGS_TAG)!;
-    const close = settings.shadowRoot!.querySelector('.close-button') as HTMLButtonElement;
+    const close = settings.shadowRoot!.querySelector('.close-button') as HTMLElement;
     fireEvent.click(close);
     await el.updateComplete;
     expect(el.shadowRoot!.querySelector(SETTINGS_TAG)).not.toBeInTheDocument();
@@ -78,7 +78,7 @@ describe('RsvpPlayer settings pane', () => {
 
     const controls = el.shadowRoot!.querySelector(CONTROLS_TAG)!;
     await (controls as any).updateComplete;
-    const button = controls.shadowRoot!.querySelector(SETTINGS_BUTTON_SELECTOR) as HTMLButtonElement;
+    const button = controls.shadowRoot!.querySelector(SETTINGS_BUTTON_SELECTOR) as HTMLElement;
     fireEvent.click(button);
     await el.updateComplete;
     const settings = el.shadowRoot!.querySelector(SETTINGS_TAG)!;
@@ -102,7 +102,7 @@ describe('RsvpPlayer settings pane', () => {
 
     const controls = el.shadowRoot!.querySelector(CONTROLS_TAG)!;
     await (controls as any).updateComplete;
-    const button = controls.shadowRoot!.querySelector(SETTINGS_BUTTON_SELECTOR) as HTMLButtonElement;
+    const button = controls.shadowRoot!.querySelector(SETTINGS_BUTTON_SELECTOR) as HTMLElement;
     fireEvent.click(button);
     await el.updateComplete;
     const settings = el.shadowRoot!.querySelector(SETTINGS_TAG)!;

--- a/webcomponents/src/components/rsvp-settings.ts
+++ b/webcomponents/src/components/rsvp-settings.ts
@@ -2,6 +2,8 @@ import { LitElement, html, css } from 'lit';
 import { property } from 'lit/decorators.js';
 import { HtmlParser, TextParser } from '../parsers/content-parser';
 import { requestSummary, LlmConfig } from '../llm/summary';
+import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-close.js';
 
 const TEXT_CHANGE_EVENT = 'text-change';
 
@@ -148,20 +150,6 @@ export class RsvpSettings extends LitElement {
       position: absolute;
       top: 10px;
       right: 10px;
-      background: transparent;
-      border: none;
-      color: #FFFFFF;
-      font-size: 24px;
-      cursor: pointer;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      border-radius: 50%;
-      transition: background-color 0.2s, color 0.2s;
-    }
-    .close-button:hover {
-      background-color: #FFFFFF;
-      color: #000000;
     }
   `;
 
@@ -352,11 +340,9 @@ export class RsvpSettings extends LitElement {
     const pasteActive = this.mode === 'paste';
     return html`
       <div class="settings-pane">
-        <button class="close-button" aria-label="Close settings" @click=${this._onClose}>
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-            <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-          </svg>
-        </button>
+        <sp-button quiet variant="secondary" class="close-button" aria-label="Close settings" @click=${this._onClose}>
+          <sp-icon-close></sp-icon-close>
+        </sp-button>
         <nav class="tabs" role="tablist">
           <button class=${pasteActive ? 'active' : ''} role="tab" aria-selected=${pasteActive} @click=${() => { this.mode = 'paste'; }}>
             Paste Text

--- a/webcomponents/src/main.ts
+++ b/webcomponents/src/main.ts
@@ -1,3 +1,4 @@
 import './styles.css';
+import '@spectrum-web-components/theme/sp-theme.js';
 import './components/rsvp-settings';
 import './components/rsvp-player';


### PR DESCRIPTION
## Summary
- use Spectrum buttons and icons in `rsvp-controls`
- update settings pane close button to Spectrum component
- wrap app in `<sp-theme>` and load theme
- adjust tests for Spectrum elements

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6860f89566a0833181bc708aea010cf9