### PR TITLE
Add PDF parsing support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ Speed-Reader is a cross-platform reading tool that presents text one word at a t
 - Settings pane for text input, URL loading and font size
 - Fullscreen toggle
 - Configurable keybindings and gestures ([defaults](features/default_keybindings.md))
-- Modular content parsers with HTML and text implementations
+- Modular content parsers with HTML, Markdown and PDF implementations
 
 ## 4. Planned Features
 1. **Configurable Control** ([feature](features/configurable_control.feature))

--- a/webcomponents/package.json
+++ b/webcomponents/package.json
@@ -17,7 +17,8 @@
     "@spectrum-web-components/icons-workflow": "^1.7.0",
     "@spectrum-web-components/reactive-controllers": "^1.7.0",
     "lit": "^2.6.1",
-    "marked": "^9.1.6"
+    "marked": "^9.1.6",
+    "pdfjs-dist": "^5.3.31"
   },
   "devDependencies": {
     "@playwright/test": "^1.42.1",

--- a/webcomponents/src/parsers/html-parser.test.ts
+++ b/webcomponents/src/parsers/html-parser.test.ts
@@ -1,11 +1,11 @@
 import { HtmlParser } from './content-parser';
 
 describe('HtmlParser', () => {
-  it('extracts visible text from html', () => {
+  it('extracts visible text from html', async () => {
     const html = `<!DOCTYPE html>
       <html><head><style>.a{}</style><script>1</script></head>
       <body><article><h1>Hello</h1><!--comment--><p>World &amp; <b>friends</b></p></article></body></html>`;
     const parser = new HtmlParser();
-    expect(parser.parse(html)).toBe('Hello World & friends');
+    await expect(parser.parse(html)).resolves.toBe('Hello World & friends');
   });
 });

--- a/webcomponents/src/parsers/markdown-parser.test.ts
+++ b/webcomponents/src/parsers/markdown-parser.test.ts
@@ -1,9 +1,9 @@
 import { MarkdownParser } from './content-parser';
 
 describe('MarkdownParser', () => {
-  it('extracts text from markdown', () => {
+  it('extracts text from markdown', async () => {
     const md = '# Hello **World**';
     const parser = new MarkdownParser();
-    expect(parser.parse(md)).toBe('Hello World');
+    await expect(parser.parse(md)).resolves.toBe('Hello World');
   });
 });

--- a/webcomponents/src/parsers/pdf-parser.test.ts
+++ b/webcomponents/src/parsers/pdf-parser.test.ts
@@ -1,0 +1,10 @@
+import { PdfParser } from './content-parser';
+import fs from 'fs';
+
+describe('PdfParser', () => {
+  it('extracts text from a simple pdf', async () => {
+    const data = fs.readFileSync(__dirname + '/sample.pdf');
+    const parser = new PdfParser();
+    await expect(parser.parse(data)).resolves.toBe('Hello World');
+  });
+});

--- a/webcomponents/src/parsers/sample.pdf
+++ b/webcomponents/src/parsers/sample.pdf
@@ -1,0 +1,36 @@
+%PDF-1.3
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 24 Tf
+100 100 Td
+(Hello World) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f
+0000000010 00000 n
+0000000053 00000 n
+0000000104 00000 n
+0000000175 00000 n
+0000000250 00000 n
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+310
+%%EOF

--- a/webcomponents/src/parsers/text-parser.test.ts
+++ b/webcomponents/src/parsers/text-parser.test.ts
@@ -1,8 +1,8 @@
 import { TextParser } from './content-parser';
 
 describe('TextParser', () => {
-  it('returns the text unchanged', () => {
+  it('returns the text unchanged', async () => {
     const parser = new TextParser();
-    expect(parser.parse('Hello world')).toBe('Hello world');
+    await expect(parser.parse('Hello world')).resolves.toBe('Hello world');
   });
 });


### PR DESCRIPTION
## Summary
- support asynchronous content parsers and add PdfParser
- handle pdf files and urls in settings pane
- update documentation about parser formats
- add unit tests including pdf fixture

## Testing
- `npm run lint` *(fails: Cannot find module '../cli-engine/cli-engine')*
- `npm test` *(fails: Cannot find module '@babel/generator/lib/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_6860fb108ff88331bb8225f0e0712be2