### PR TITLE
Update settings UI with Adobe Spectrum

### DIFF
--- a/webcomponents/jest.setup.ts
+++ b/webcomponents/jest.setup.ts
@@ -1,1 +1,20 @@
 import '@testing-library/jest-dom';
+
+class DummyObserver {
+  observe() {
+    // no-op for tests
+  }
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+
+// Polyfill observers used by Spectrum
+if (!('ResizeObserver' in global)) {
+  (global as any).ResizeObserver = DummyObserver;
+}
+if (!('IntersectionObserver' in global)) {
+  (global as any).IntersectionObserver = DummyObserver;
+}

--- a/webcomponents/package.json
+++ b/webcomponents/package.json
@@ -17,7 +17,11 @@
     "@spectrum-web-components/icons-workflow": "^1.7.0",
     "@spectrum-web-components/reactive-controllers": "^1.7.0",
     "lit": "^2.6.1",
-    "marked": "^9.1.6"
+    "marked": "^9.1.6",
+    "@spectrum-web-components/button": "^1.7.0",
+    "@spectrum-web-components/tabs": "^1.7.0",
+    "@spectrum-web-components/textfield": "^1.7.0",
+    "@spectrum-web-components/field-label": "^1.7.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.42.1",

--- a/webcomponents/src/components/rsvp-controls.ts
+++ b/webcomponents/src/components/rsvp-controls.ts
@@ -2,6 +2,14 @@ import { LitElement, html, css } from 'lit';
 import { property } from 'lit/decorators.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-full-screen.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-full-screen-exit.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-play.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-pause.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-replay.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-rewind.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-fast-forward.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-remove.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-add.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
 
 export class RsvpControls extends LitElement {
     static properties = {
@@ -94,13 +102,13 @@ export class RsvpControls extends LitElement {
         let playPauseIcon;
         let playPauseLabel = 'Play';
         if (this.isEnded) {
-            playPauseIcon = html`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12 5V1L7 6l5 5V7c3.86 0 7 3.14 7 7s-3.14 7-7 7-7-3.14-7-7h2c0 2.76 2.24 5 5 5s5-2.24 5-5-2.24-5-5-5z"/></svg>`;
+            playPauseIcon = html`<sp-icon-replay></sp-icon-replay>`;
             playPauseLabel = 'Replay';
         } else if (this.playing) {
-            playPauseIcon = html`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>`;
+            playPauseIcon = html`<sp-icon-pause></sp-icon-pause>`;
             playPauseLabel = 'Pause';
         } else {
-            playPauseIcon = html`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>`;
+            playPauseIcon = html`<sp-icon-play></sp-icon-play>`;
         }
         return html`
       <div class="controls">
@@ -109,19 +117,19 @@ export class RsvpControls extends LitElement {
             ${playPauseIcon}
           </button>
           <button @click=${this._onRewind} aria-label="Rewind">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M11 18V6l-8.5 6 8.5 6zm.5-6l8.5 6V6l-8.5 6z"/></svg>
+            <sp-icon-rewind></sp-icon-rewind>
           </button>
           <button @click=${this._onFastForward} aria-label="Fast Forward">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="m4 18 8.5-6L4 6v12zm9-12v12l8.5-6L13 6z"/></svg>
+            <sp-icon-fast-forward></sp-icon-fast-forward>
           </button>
         </div>
         <span class="wpm">${this.wpm} WPM</span>
         <div class="control-group">
           <button @click=${this._onDecreaseSpeed} aria-label="Decrease speed">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M19 13H5v-2h14v2z"/></svg>
+            <sp-icon-remove></sp-icon-remove>
           </button>
           <button @click=${this._onIncreaseSpeed} aria-label="Increase speed">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>
+            <sp-icon-add></sp-icon-add>
           </button>
           <button @click=${this._onToggleFullscreen} aria-label="Toggle Fullscreen">
             ${this.isFullscreen
@@ -129,9 +137,7 @@ export class RsvpControls extends LitElement {
               : html`<sp-icon-full-screen></sp-icon-full-screen>`}
           </button>
           <button @click=${this._onToggleSettings} aria-label="Settings" part="settings-button">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M19.43 12.98c.04-.32.07-.66.07-1s-.03-.68-.07-1l2.11-1.65a.5.5 0 0 0 .12-.62l-2-3.46a.5.5 0 0 0-.6-.22l-2.49 1a7.07 7.07 0 0 0-1.52-.88l-.38-2.65a.5.5 0 0 0-.49-.42h-4.16a.5.5 0 0 0-.49.42l-.38 2.65a6.96 6.96 0 0 0-1.52.88l-2.49-1a.5.5 0 0 0-.6.22l-2 3.46a.5.5 0 0 0 .12.62L4.57 10c-.04.32-.07.66-.07 1s.03.68.07 1l-2.11 1.65a.5.5 0 0 0-.12.62l2 3.46a.5.5 0 0 0 .6.22l2.49-1c.47.39.99.71 1.52.88l.38 2.65c.03.24.25.42.49.42h4.16c.24 0 .46-.18.49-.42l.38-2.65c.53-.2 1.05-.49 1.52-.88l2.49 1a.5.5 0 0 0 .6-.22l2-3.46a.5.5 0 0 0-.12-.62L19.43 12.98zM12 15.5a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7z"/>
-            </svg>
+            <sp-icon-settings></sp-icon-settings>
           </button>
         </div>
       </div>

--- a/webcomponents/src/components/rsvp-settings.ts
+++ b/webcomponents/src/components/rsvp-settings.ts
@@ -1,5 +1,11 @@
 import { LitElement, html, css } from 'lit';
 import { property } from 'lit/decorators.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-close.js';
+import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/tabs/sp-tabs.js';
+import '@spectrum-web-components/tabs/sp-tab.js';
+import '@spectrum-web-components/textfield/sp-textfield.js';
+import '@spectrum-web-components/field-label/sp-field-label.js';
 import {
   HtmlParser,
   MarkdownParser,
@@ -87,25 +93,7 @@ export class RsvpSettings extends LitElement {
       max-width: 400px;
     }
 
-    .tabs {
-      display: flex;
-      gap: 8px;
-      width: 100%;
-      max-width: 400px;
-    }
 
-    .tabs button {
-      flex: 1;
-      padding: 8px;
-      border: 1px solid #555;
-      background-color: #222;
-      color: #fff;
-      cursor: pointer;
-    }
-
-    .tabs button.active {
-      background-color: #ff0000;
-    }
 
     .settings-pane label {
       display: block;
@@ -394,42 +382,37 @@ export class RsvpSettings extends LitElement {
     const pasteActive = this.mode === 'paste';
     return html`
       <div class="settings-pane">
-        <button class="close-button" aria-label="Close settings" @click=${this._onClose}>
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-            <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-          </svg>
-        </button>
-        <nav class="tabs" role="tablist">
-          <button class=${pasteActive ? 'active' : ''} role="tab" aria-selected=${pasteActive} @click=${() => { this.mode = 'paste'; }}>
-            Paste Text
-          </button>
-          <button class=${pasteActive ? '' : 'active'} role="tab" aria-selected=${!pasteActive} @click=${() => { this.mode = 'url'; }}>
-            From URL
-          </button>
-        </nav>
+        <sp-button class="close-button" quiet aria-label="Close settings" @click=${this._onClose}>
+          <sp-icon-close></sp-icon-close>
+        </sp-button>
+        <sp-tabs selected=${pasteActive ? 'paste' : 'url'} @change=${(e: Event) => { this.mode = (e.target as any).selected as 'paste' | 'url'; }}>
+          <sp-tab value="paste">Paste Text</sp-tab>
+          <sp-tab value="url">From URL</sp-tab>
+        </sp-tabs>
         ${pasteActive ? html`
           <div>
-            <label for="text-input">Text to Display:</label>
-            <textarea
+            <sp-field-label for="text-input">Text to Display:</sp-field-label>
+            <sp-textfield
+              multiline
               id="text-input"
               .value=${this.text}
               @input=${this._onTextInput}
               ?readonly=${this.mode === 'url'}
               aria-readonly=${this.mode === 'url'}
-            ></textarea>
-            <label for="file-input">Import File:
-              <input
-                id="file-input"
-                type="file"
-                accept=".txt,.html,.md,.markdown,.docx,.odt,text/plain,text/html,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.oasis.opendocument.text"
-                @change=${this._onFileChange}
-              ></label>
+            ></sp-textfield>
+            <sp-field-label for="file-input">Import File:</sp-field-label>
+            <input
+              id="file-input"
+              type="file"
+              accept=".txt,.html,.md,.markdown,.docx,.odt,text/plain,text/html,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.oasis.opendocument.text"
+              @change=${this._onFileChange}
+            >
           </div>
         ` : html`
           <div>
-            <label for="url-input">URL to Load:</label>
-            <input id="url-input" type="url" .value=${this.url} @input=${this._onUrlInput}>
-            <button class="load-url" @click=${this._loadUrl}>Load Content</button>
+            <sp-field-label for="url-input">URL to Load:</sp-field-label>
+            <sp-textfield id="url-input" type="url" .value=${this.url} @input=${this._onUrlInput}></sp-textfield>
+            <sp-button class="load-url" @click=${this._loadUrl}>Load Content</sp-button>
           </div>
         `}
         <fieldset>


### PR DESCRIPTION
## Summary
- integrate Adobe Spectrum Web Components
- refactor settings layout with Spectrum tabs and text fields
- replace inline SVGs with Spectrum icon components
- add polyfills for tests

## Testing
- `npm run lint`
- `npm test` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_686121107510833199bb7b4e29021e7f