### PR TITLE
Adjust sentence indicator bar position

### DIFF
--- a/webcomponents/src/components/rsvp-player.ts
+++ b/webcomponents/src/components/rsvp-player.ts
@@ -143,12 +143,13 @@ export class RsvpPlayer extends LitElement {
 
     .sentence-progress {
       position: absolute;
-      bottom: -2px;
-      left: 0;
+      bottom: 0;
+      left: 50%;
       height: 2px;
       background-color: #FF0000;
       width: 100%;
       pointer-events: none;
+      transform: translateX(-50%);
       transition: width 0.1s linear;
     }
 


### PR DESCRIPTION
## Summary
- center the sentence progress bar and align it directly under the word

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686188bfe8a883319549c2ba3c7cc9b4