### PR TITLE
Handle missing sentence markers

### DIFF
--- a/docs/architecture/playback-format.md
+++ b/docs/architecture/playback-format.md
@@ -17,7 +17,7 @@ The format is designed to capture all timing and punctuation information while r
 ```
 
 - **tokens[]** – words in playback order.
-- **markers** – sentence level punctuation such as `?` or `!` applied to all words in the sentence.
+- **markers** – sentence level punctuation such as `.`, `?`, `!` or `;` applied to all words in the sentence. If a sentence lacks punctuation, a single space character is used.
 - **text** – literal word to display.
 - **scopes** – array of opening punctuation currently in scope. The player renders matching closing characters after the word.
 - **delay** – additional display intervals beyond the base WPM rate.

--- a/docs/design/punctuation-rules.md
+++ b/docs/design/punctuation-rules.md
@@ -6,15 +6,18 @@ The RSVP player handles punctuation to preserve reading rhythm while signalling 
   - A sentence ending with `?` displays a question mark below every word in that sentence.
   - A sentence ending with `!` shows an exclamation mark below every word.
   - If a sentence ends with both (`?!` or `!?`), both symbols appear beneath each word.
+  - A sentence ending with `.` shows a period below every word.
+  - A sentence ending with `;` shows a semicolon marker and then starts a new sentence.
 - **Ellipses**
   - An ellipsis (`...`) is rendered as a sequence of three words: `.` then `..` then `...`.
   - Each period remains onscreen until the full ellipsis is shown, using the current WPM delay for each step.
 - **Commas**
   - Commas do not appear onscreen but cause the preceding word to stay for one extra delay interval.
 - **Colons & Semicolons**
-  - `:` and `;` are treated like commas. They are hidden and add one extra delay to the word before them.
+  - `:` is treated like a comma and adds one extra delay to the word before it.
 - **Periods**
-  - A period that ends a sentence does not display and has no extra delay.
+  - Periods ending a sentence are displayed as markers with no extra delay.
+  - Sentences without an ending marker use a blank space so the marker row stays aligned.
 - **Default**
   - Any other punctuation characters remain as part of the word and do not alter timing.
 

--- a/webcomponents/src/components/rsvp-punctuation.test.ts
+++ b/webcomponents/src/components/rsvp-punctuation.test.ts
@@ -13,9 +13,20 @@ describe('parseText punctuation rules', () => {
     expect(tokens[0].markers.sort()).toEqual(['!', '?']);
   });
 
+  it('assigns period marker to sentence words', () => {
+    const tokens = parseText('Hello.');
+    expect(tokens[0].markers).toEqual(['.']);
+  });
+
   it('creates incremental ellipsis tokens', () => {
     const tokens = parseText('Wait...');
     expect(tokens.map(t => t.text)).toEqual(['Wait', '.', '..', '...']);
+  });
+
+  it('uses blank marker when sentence lacks punctuation', () => {
+    const tokens = parseText('No marker');
+    expect(tokens[0].markers).toEqual([' ']);
+    expect(tokens[1].markers).toEqual([' ']);
   });
 
   it('adds pause after comma', () => {
@@ -34,5 +45,6 @@ describe('parseText punctuation rules', () => {
     const tokens = parseText('First; second');
     expect(tokens.map(t => t.text)).toEqual(['First', 'second']);
     expect(tokens[0].extraPause).toBe(1);
+    expect(tokens[0].markers).toEqual([';']);
   });
 });

--- a/webcomponents/src/parsers/tokenizer.ts
+++ b/webcomponents/src/parsers/tokenizer.ts
@@ -81,11 +81,21 @@ export function parseText(text: string): Token[] {
         const last = tokens.at(-1)!;
         last.extraPause += 1;
       }
+      if (ch === ';') {
+        const dedup = [';'];
+        for (const idx of sentenceIndices) {
+          tokens[idx].markers = dedup;
+        }
+        if (sentenceIndices.length > 0) {
+          tokens[sentenceIndices.at(-1)!].sentenceEnd = true;
+        }
+        sentenceIndices = [];
+      }
       i++;
       continue;
     }
 
-    if (ch === '.' || ch === '!' || ch === '?') {
+    if (ch === '.' || ch === '!' || ch === '?' ) {
       pushWord();
       let j = i;
       const markers: string[] = [];
@@ -94,16 +104,17 @@ export function parseText(text: string): Token[] {
           break;
         }
         const c = text[j];
-        if (c === '!' || c === '?') {
+        if (c === '!' || c === '?' || c === '.' ) {
           markers.push(c);
-        } else if (c !== '.') {
+        } else {
           break;
         }
         j++;
       }
       const dedup = [...new Set(markers)];
+      const finalMarkers = dedup.length > 0 ? dedup : [' '];
       for (const idx of sentenceIndices) {
-        tokens[idx].markers = dedup;
+        tokens[idx].markers = finalMarkers;
       }
       if (sentenceIndices.length > 0) {
         tokens[sentenceIndices.at(-1)!].sentenceEnd = true;
@@ -118,6 +129,9 @@ export function parseText(text: string): Token[] {
   }
   pushWord();
   if (sentenceIndices.length > 0) {
+    for (const idx of sentenceIndices) {
+      tokens[idx].markers = [' '];
+    }
     tokens[sentenceIndices.at(-1)!].sentenceEnd = true;
   }
   return tokens;


### PR DESCRIPTION
## Summary
- capture period and semicolon punctuation
- default sentence markers to a blank space when punctuation is missing
- update tests for new punctuation behaviour
- document how sentence markers work in the playback format and punctuation rules

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68625a1152148331a3172293537edf24