### PR TITLE
Improve settings pane docs and add WPM+provider controls

### DIFF
--- a/docs/design/components/settings-dialog.md
+++ b/docs/design/components/settings-dialog.md
@@ -28,6 +28,37 @@
 - Focus trap: Tokenized focus ring
 - Touch: swipe down to close on mobile
 
+## Configurable Fields
+
+### Content Input
+- **Paste Text** – multiline field for manual text entry.
+- **Import File** – accepts `.txt`, `.html`, `.md`, `.docx` and `.odt` files.
+- **URL to Load** – fetches remote content into the reader.
+
+### Reading Preferences
+- **Words Per Minute** – numeric value from 100–800 to set the initial speed.
+- **LLM Provider** – choose `OpenRouter` or `OpenAI` for summaries.
+- **API Key** – secret token for the selected provider.
+- **Model** – LLM model identifier used when summarizing.
+- **Summarize text before reading** – toggle to request a short summary.
+
+### Keyboard Shortcuts
+- Play/Pause key
+- Increase Speed key
+- Decrease Speed key
+- Rewind key
+- Fast Forward key
+
+### Gestures
+- Swipe Fast-Forward/Rewind
+- Tap Controls
+- Swipe Settings
+
+## UX Requirements
+- Swipe up on the player opens the settings pane when enabled.
+- Swipe down on the pane closes it and must prevent page refresh.
+- Controls follow Adobe Spectrum patterns for spacing and focus states.
+
 ## References
 - [Requirements](../../README.md)
 - [Design Tokens](../tokens/)

--- a/docs/design/components/settings-dialog.md
+++ b/docs/design/components/settings-dialog.md
@@ -2,8 +2,8 @@
 
 ## Anatomy
 - Root (`<sr-settings-dialog>`)
-- Dialog Overlay (`.overlay`)
-- Dialog Panel (`.panel`)
+- Theme Wrapper (`<sp-theme>`) providing Spectrum color and scale
+- Dialog Panel (`.panel` in `<sp-dialog>`)
 - Spectrum Accordion groups (`<sp-accordion>`)
 - Tabs (`<sp-tabs>`) for Paste and URL modes
 - Text Input Area (`<sp-textfield multiline>`)

--- a/docs/design/components/settings-dialog.md
+++ b/docs/design/components/settings-dialog.md
@@ -4,10 +4,11 @@
 - Root (`<sr-settings-dialog>`)
 - Dialog Overlay (`.overlay`)
 - Dialog Panel (`.panel`)
-- Tabs (`.tabs`) for Paste and URL modes
-- Text Input Area (`textarea`)
+- Spectrum Accordion groups (`<sp-accordion>`)
+- Tabs (`<sp-tabs>`) for Paste and URL modes
+- Text Input Area (`<sp-textfield multiline>`)
 - Dynamic Font Sizing (automatic based on player size)
-- Close Button (`button`)
+- Close Button (`<sp-close-button>`)
 
 ## States
 - Open / Closed
@@ -27,6 +28,7 @@
 - Keyboard: Tab navigation, Esc (close)
 - Focus trap: Tokenized focus ring
 - Touch: swipe down to close on mobile
+- Groups are organized in an accordion to reduce scrolling on mobile.
 
 ## Configurable Fields
 

--- a/docs/design/decisions/0006-settings-pane-redesign.md
+++ b/docs/design/decisions/0006-settings-pane-redesign.md
@@ -15,3 +15,5 @@ We evaluated new layouts for the settings pane following the Adobe Spectrum desi
    - *Cons:* overwhelming on small screens, harder to find specific options.
 
 Option 2 provides the best balance of discoverability and minimal cognitive load. It keeps related settings together while allowing users to collapse groups they rarely change. The accordion layout is therefore chosen for implementation and implemented with Spectrum `<sp-accordion>` components to align with the design system.
+
+To ensure consistent theming across Spectrum components, the pane is wrapped in `<sp-theme>` and uses `<sp-dialog>` styles. This fixes the plain appearance noted in earlier prototypes and positions icons correctly.

--- a/docs/design/decisions/0006-settings-pane-redesign.md
+++ b/docs/design/decisions/0006-settings-pane-redesign.md
@@ -1,0 +1,17 @@
+# Decision: Settings Pane Redesign
+
+We evaluated new layouts for the settings pane following the Adobe Spectrum design guidelines. Three options were considered:
+
+1. **Tabbed sections** – a dedicated tab for each category (Input, Reading, Shortcuts, Gestures).
+   - *Pros:* clear separation of concerns, small scrolling regions.
+   - *Cons:* extra taps to navigate between tabs, harder to discover options on mobile.
+
+2. **Accordion groups** – a single scrolling surface with collapsible groups.
+   - *Pros:* progressive disclosure keeps the screen short, easy to scan.
+   - *Cons:* requires Javascript to manage open state but works well with keyboard and screen readers.
+
+3. **Long scroll form** – all controls in one column.
+   - *Pros:* very simple implementation.
+   - *Cons:* overwhelming on small screens, harder to find specific options.
+
+Option 2 provides the best balance of discoverability and minimal cognitive load. It keeps related settings together while allowing users to collapse groups they rarely change. The accordion layout is therefore chosen for implementation.

--- a/docs/design/decisions/0006-settings-pane-redesign.md
+++ b/docs/design/decisions/0006-settings-pane-redesign.md
@@ -14,4 +14,4 @@ We evaluated new layouts for the settings pane following the Adobe Spectrum desi
    - *Pros:* very simple implementation.
    - *Cons:* overwhelming on small screens, harder to find specific options.
 
-Option 2 provides the best balance of discoverability and minimal cognitive load. It keeps related settings together while allowing users to collapse groups they rarely change. The accordion layout is therefore chosen for implementation.
+Option 2 provides the best balance of discoverability and minimal cognitive load. It keeps related settings together while allowing users to collapse groups they rarely change. The accordion layout is therefore chosen for implementation and implemented with Spectrum `<sp-accordion>` components to align with the design system.

--- a/docs/features/settings_pane.feature
+++ b/docs/features/settings_pane.feature
@@ -1,0 +1,18 @@
+Feature: Settings Pane
+  The reader offers configurable settings to accommodate different workflows.
+
+  Scenario: Adjusting reading preferences
+    When I set "Words Per Minute" to 350
+    Then the player starts new sessions at 350 WPM
+
+  Scenario: Selecting an LLM provider
+    When I choose "OpenAI" in the provider select
+    Then summaries are requested from the OpenAI API
+
+  Scenario: Customising keyboard shortcuts
+    When I change the Play/Pause key to "P"
+    Then pressing "P" toggles playback
+
+  Scenario: Toggling gesture controls
+    When I disable "Swipe Settings"
+    Then swiping up does not open the settings pane

--- a/docs/features/settings_pane.feature
+++ b/docs/features/settings_pane.feature
@@ -1,6 +1,8 @@
 Feature: Settings Pane
   The reader offers configurable settings to accommodate different workflows.
 
+  The pane groups related options in an accordion to reduce scrolling.
+
   Scenario: Adjusting reading preferences
     When I set "Words Per Minute" to 350
     Then the player starts new sessions at 350 WPM

--- a/webcomponents/package.json
+++ b/webcomponents/package.json
@@ -21,6 +21,8 @@
     "@spectrum-web-components/reactive-controllers": "^1.7.0",
     "@spectrum-web-components/tabs": "^1.7.0",
     "@spectrum-web-components/textfield": "^1.7.0",
+    "@spectrum-web-components/theme": "^1.7.0",
+    "@spectrum-web-components/dialog": "^1.7.0",
     "lit": "^2.6.1",
     "marked": "^9.1.6"
   },

--- a/webcomponents/package.json
+++ b/webcomponents/package.json
@@ -14,14 +14,15 @@
     "lint": "npm run lint:js && npm run lint:css"
   },
   "dependencies": {
+    "@spectrum-web-components/accordion": "^1.7.0",
+    "@spectrum-web-components/button": "^1.7.0",
+    "@spectrum-web-components/field-label": "^1.7.0",
     "@spectrum-web-components/icons-workflow": "^1.7.0",
     "@spectrum-web-components/reactive-controllers": "^1.7.0",
-    "lit": "^2.6.1",
-    "marked": "^9.1.6",
-    "@spectrum-web-components/button": "^1.7.0",
     "@spectrum-web-components/tabs": "^1.7.0",
     "@spectrum-web-components/textfield": "^1.7.0",
-    "@spectrum-web-components/field-label": "^1.7.0"
+    "lit": "^2.6.1",
+    "marked": "^9.1.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.42.1",

--- a/webcomponents/src/components/rsvp-player.ts
+++ b/webcomponents/src/components/rsvp-player.ts
@@ -281,9 +281,11 @@ export class RsvpPlayer extends LitElement {
       ${this.showSettingsPane ? html`
         <rsvp-settings
           .text=${this.text}
+          .wpm=${this.wpm}
           .keybindings=${this.keybindings}
           .gestures=${this.gestures}
           @text-change=${(e: CustomEvent) => this.text = e.detail}
+          @wpm-change=${(e: CustomEvent<number>) => this.wpm = e.detail}
           @keybindings-change=${(e: CustomEvent<Keybindings>) => this.keybindings = e.detail}
           @gestures-change=${(e: CustomEvent<GestureSettings>) => this.gestures = e.detail}
           @close=${this._toggleSettingsPane}

--- a/webcomponents/src/components/rsvp-settings.test.ts
+++ b/webcomponents/src/components/rsvp-settings.test.ts
@@ -78,10 +78,9 @@ describe('RsvpSettings', () => {
 
     jest.spyOn(window as any, 'FileReader').mockRestore?.();
     Object.defineProperty(input, 'files', { value: [file] });
+    const wait = new Promise(resolve => el.addEventListener(CHANGE_EVENT, resolve));
     fireEvent.change(input);
-    await el.updateComplete;
-    await flush();
-    await flush();
+    await wait;
     const field = el.shadowRoot!.querySelector(TEXTFIELD_SELECTOR) as any;
     expect(field.value).toBe('Hello File');
   });
@@ -130,5 +129,16 @@ describe('RsvpSettings', () => {
     fireEvent.change(select);
     await el.updateComplete;
     expect(el.llmConfig.provider).toBe('openai');
+  });
+
+  it('emits close event when button clicked', async () => {
+    const el = document.querySelector(TAG) as RsvpSettings;
+    await el.updateComplete;
+    const button = el.shadowRoot!.querySelector('.close-button') as HTMLElement;
+    const spy = jest.fn();
+    el.addEventListener('close', spy);
+    fireEvent.click(button);
+    await el.updateComplete;
+    expect(spy).toHaveBeenCalled();
   });
 });

--- a/webcomponents/src/components/rsvp-settings.test.ts
+++ b/webcomponents/src/components/rsvp-settings.test.ts
@@ -108,4 +108,27 @@ describe('RsvpSettings', () => {
     await (el as any)._loadUrl();
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it('emits wpm-change when wpm updated', async () => {
+    const el = document.querySelector(TAG) as RsvpSettings;
+    await el.updateComplete;
+    const input = el.shadowRoot!.querySelector('#setting-wpm') as HTMLInputElement;
+    const spy = jest.fn();
+    el.addEventListener('wpm-change', spy);
+    input.value = '350';
+    fireEvent.input(input);
+    await el.updateComplete;
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ detail: 350 }));
+  });
+
+  it('allows selecting llm provider', async () => {
+    const el = document.querySelector(TAG) as RsvpSettings;
+    await el.updateComplete;
+    const select = el.shadowRoot!.querySelector('#llm-provider') as HTMLSelectElement;
+    expect(select.value).toBe('openrouter');
+    select.value = 'openai';
+    fireEvent.change(select);
+    await el.updateComplete;
+    expect(el.llmConfig.provider).toBe('openai');
+  });
 });

--- a/webcomponents/src/components/rsvp-settings.ts
+++ b/webcomponents/src/components/rsvp-settings.ts
@@ -3,10 +3,13 @@ import { property } from 'lit/decorators.js';
 import '@spectrum-web-components/accordion/sp-accordion.js';
 import '@spectrum-web-components/accordion/sp-accordion-item.js';
 import '@spectrum-web-components/button/sp-close-button.js';
+import '@spectrum-web-components/button/sp-button.js';
 import '@spectrum-web-components/tabs/sp-tabs.js';
 import '@spectrum-web-components/tabs/sp-tab.js';
 import '@spectrum-web-components/textfield/sp-textfield.js';
 import '@spectrum-web-components/field-label/sp-field-label.js';
+import '@spectrum-web-components/theme/sp-theme.js';
+import '@spectrum-web-components/dialog/sp-dialog.js';
 import {
   HtmlParser,
   MarkdownParser,
@@ -58,17 +61,25 @@ export class RsvpSettings extends LitElement {
 
   static styles = css`
     :host {
-      position: absolute;
+      position: fixed;
       inset: 0;
-      background-color: rgba(0, 0, 0, 0.9);
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: flex-start;
-      padding: 20px;
-      z-index: 10;
-      overflow-y: auto;
+      display: grid;
+      place-items: center;
+      background-color: rgba(0, 0, 0, 0.7);
       overscroll-behavior: contain;
+      z-index: 1000;
+    }
+
+    .panel {
+      width: 90vw;
+      max-width: 480px;
+      max-height: 90vh;
+      overflow-y: auto;
+      background-color: var(--spectrum-global-color-gray-50);
+      color: var(--spectrum-alias-text-color);
+      border-radius: var(--spectrum-alias-border-radius-medium);
+      padding: var(--spectrum-global-dimension-size-200);
+      box-shadow: var(--spectrum-global-shadow-medium);
       transform: translateY(100%);
       animation: slide-up 0.3s ease-out forwards;
     }
@@ -83,80 +94,21 @@ export class RsvpSettings extends LitElement {
     }
 
     @media (max-width: 600px) {
-      :host {
-        padding: 10px;
+      .panel {
+        width: 100%;
+        height: 100%;
+        max-width: none;
+        border-radius: 0;
       }
     }
 
-    .dialog {
-      position: relative;
-      width: 100%;
-      max-width: 480px;
-      color: #FFFFFF;
-    }
-
-    .dialog label {
-      display: block;
-      margin-bottom: 5px;
-    }
-
-    .dialog textarea,
-    .dialog input[type="number"],
-    .dialog input[type="range"],
-    .dialog input[type="url"] {
-      width: 100%;
-      padding: var(--sr-spacing-sm, 8px);
-      border-radius: var(--sr-radius-md, 4px);
-      border: 1px solid #555;
-      background-color: #333;
-      color: #FFFFFF;
-      box-sizing: border-box;
-    }
-    .dialog textarea {
-      min-height: 40vh;
-      max-height: 60vh;
-      resize: vertical;
-    }
-    @media (max-width: 600px) {
-      .dialog textarea {
-        min-height: 30vh;
-      }
-    }
-
-    .dialog sp-button,
-    .dialog button {
-      background-color: #FF0000;
-      color: #FFFFFF;
-      border: none;
-      padding: 10px 15px;
-      cursor: pointer;
-      font-size: 1rem;
-      border-radius: 4px;
-      margin-top: 10px;
-    }
-    .dialog sp-button:hover,
-    .dialog button:hover {
-      background-color: #CC0000;
-    }
-
-    .close-button {
-      position: absolute;
-      top: 10px;
-      right: 10px;
-      background: transparent;
-      border: none;
-      color: #FFFFFF;
-      font-size: 24px;
-      cursor: pointer;
+    .close-row {
       display: flex;
-      align-items: center;
-      justify-content: center;
-      border-radius: 50%;
-      transition: background-color 0.2s, color 0.2s;
+      justify-content: flex-end;
     }
-    .close-button:hover {
-      background-color: #FFFFFF;
-      color: #000000;
+
+    sp-accordion {
+      margin-top: var(--spectrum-global-dimension-size-200);
     }
   `;
 
@@ -297,7 +249,9 @@ export class RsvpSettings extends LitElement {
   }
 
   private _onClose() {
-    this.dispatchEvent(new CustomEvent('close'));
+    this.dispatchEvent(
+      new CustomEvent('close', { bubbles: true, composed: true })
+    );
   }
 
   private _touchStartY = 0;
@@ -383,14 +337,17 @@ export class RsvpSettings extends LitElement {
   render() {
     const pasteActive = this.mode === 'paste';
     return html`
-      <div class="dialog" role="dialog" aria-label="Settings">
-        <sp-close-button class="close-button" @click=${this._onClose} quiet></sp-close-button>
-        <sp-accordion allow-multiple>
-          <sp-accordion-item label="Content" open>
-            <sp-tabs
-              selected=${pasteActive ? 'paste' : 'url'}
-              @change=${(e: Event) => { this.mode = (e.target as any).selected as 'paste' | 'url'; }}>
-              <sp-tab value="paste">Paste Text</sp-tab>
+      <sp-theme color="dark" scale="medium">
+        <div class="panel" role="dialog" aria-label="Settings">
+          <div class="close-row">
+            <sp-close-button class="close-button" @click=${this._onClose} quiet></sp-close-button>
+          </div>
+          <sp-accordion allow-multiple>
+            <sp-accordion-item label="Content" open>
+              <sp-tabs
+                selected=${pasteActive ? 'paste' : 'url'}
+                @change=${(e: Event) => { this.mode = (e.target as any).selected as 'paste' | 'url'; }}>
+                <sp-tab value="paste">Paste Text</sp-tab>
               <sp-tab value="url">From URL</sp-tab>
             </sp-tabs>
             ${pasteActive ? html`
@@ -416,7 +373,7 @@ export class RsvpSettings extends LitElement {
               <div>
                 <sp-field-label for="url-input">URL to Load:</sp-field-label>
                 <sp-textfield id="url-input" type="url" .value=${this.url} @input=${this._onUrlInput}></sp-textfield>
-                <button class="load-url" @click=${this._loadUrl}>Load Content</button>
+                <sp-button class="load-url" variant="primary" @click=${this._loadUrl}>Load Content</sp-button>
               </div>
             `}
           </sp-accordion-item>
@@ -472,8 +429,9 @@ export class RsvpSettings extends LitElement {
             <label><input type="checkbox" .checked=${this.gestures.taps} @change=${(e: Event) => this._onGestureToggle('taps', e)}> Tap Controls</label>
             <label><input type="checkbox" .checked=${this.gestures.settingsSwipe} @change=${(e: Event) => this._onGestureToggle('settingsSwipe', e)}> Swipe Settings</label>
           </sp-accordion-item>
-        </sp-accordion>
-      </div>
+          </sp-accordion>
+        </div>
+      </sp-theme>
     `;
   }
 }

--- a/webcomponents/src/components/rsvp-settings.ts
+++ b/webcomponents/src/components/rsvp-settings.ts
@@ -1,7 +1,8 @@
 import { LitElement, html, css } from 'lit';
 import { property } from 'lit/decorators.js';
-import '@spectrum-web-components/icons-workflow/icons/sp-icon-close.js';
-import '@spectrum-web-components/button/sp-button.js';
+import '@spectrum-web-components/accordion/sp-accordion.js';
+import '@spectrum-web-components/accordion/sp-accordion-item.js';
+import '@spectrum-web-components/button/sp-close-button.js';
 import '@spectrum-web-components/tabs/sp-tabs.js';
 import '@spectrum-web-components/tabs/sp-tab.js';
 import '@spectrum-web-components/textfield/sp-textfield.js';
@@ -87,24 +88,22 @@ export class RsvpSettings extends LitElement {
       }
     }
 
-    .settings-pane div {
-      margin-bottom: 15px;
-      width: 80%;
-      max-width: 400px;
-    }
-
-
-
-    .settings-pane label {
-      display: block;
-      margin-bottom: 5px;
+    .dialog {
+      position: relative;
+      width: 100%;
+      max-width: 480px;
       color: #FFFFFF;
     }
 
-    .settings-pane textarea,
-    .settings-pane input[type="number"],
-    .settings-pane input[type="range"],
-    .settings-pane input[type="url"] {
+    .dialog label {
+      display: block;
+      margin-bottom: 5px;
+    }
+
+    .dialog textarea,
+    .dialog input[type="number"],
+    .dialog input[type="range"],
+    .dialog input[type="url"] {
       width: 100%;
       padding: var(--sr-spacing-sm, 8px);
       border-radius: var(--sr-radius-md, 4px);
@@ -113,18 +112,19 @@ export class RsvpSettings extends LitElement {
       color: #FFFFFF;
       box-sizing: border-box;
     }
-    .settings-pane textarea {
+    .dialog textarea {
       min-height: 40vh;
       max-height: 60vh;
       resize: vertical;
     }
     @media (max-width: 600px) {
-      .settings-pane textarea {
+      .dialog textarea {
         min-height: 30vh;
       }
     }
 
-    .settings-pane button {
+    .dialog sp-button,
+    .dialog button {
       background-color: #FF0000;
       color: #FFFFFF;
       border: none;
@@ -134,7 +134,8 @@ export class RsvpSettings extends LitElement {
       border-radius: 4px;
       margin-top: 10px;
     }
-    .settings-pane button:hover {
+    .dialog sp-button:hover,
+    .dialog button:hover {
       background-color: #CC0000;
     }
 
@@ -382,96 +383,96 @@ export class RsvpSettings extends LitElement {
   render() {
     const pasteActive = this.mode === 'paste';
     return html`
-      <div class="settings-pane">
-        <sp-button class="close-button" quiet aria-label="Close settings" @click=${this._onClose}>
-          <sp-icon-close></sp-icon-close>
-        </sp-button>
-        <sp-tabs selected=${pasteActive ? 'paste' : 'url'} @change=${(e: Event) => { this.mode = (e.target as any).selected as 'paste' | 'url'; }}>
-          <sp-tab value="paste">Paste Text</sp-tab>
-          <sp-tab value="url">From URL</sp-tab>
-        </sp-tabs>
-        ${pasteActive ? html`
-          <div>
-            <sp-field-label for="text-input">Text to Display:</sp-field-label>
-            <sp-textfield
-              multiline
-              id="text-input"
-              .value=${this.text}
-              @input=${this._onTextInput}
-              ?readonly=${this.mode === 'url'}
-              aria-readonly=${this.mode === 'url'}
-            ></sp-textfield>
-            <sp-field-label for="file-input">Import File:</sp-field-label>
-            <input
-              id="file-input"
-              type="file"
-              accept=".txt,.html,.md,.markdown,.docx,.odt,text/plain,text/html,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.oasis.opendocument.text"
-              @change=${this._onFileChange}
-            >
-          </div>
-        ` : html`
-          <div>
-            <sp-field-label for="url-input">URL to Load:</sp-field-label>
-            <sp-textfield id="url-input" type="url" .value=${this.url} @input=${this._onUrlInput}></sp-textfield>
-            <sp-button class="load-url" @click=${this._loadUrl}>Load Content</sp-button>
-          </div>
-        `}
-        <fieldset>
-          <legend>Reading Settings</legend>
-          <label>Words Per Minute
-            <input
-              id="setting-wpm"
-              type="number"
-              min="100"
-              max="800"
-              .value=${String(this.wpm)}
-              @input=${this._onWpmInput}
-            >
-          </label>
-        </fieldset>
-        <fieldset>
-          <legend>LLM Summary</legend>
-          <label>Provider
-            <select id="llm-provider" .value=${this.llmConfig.provider} @change=${(e: Event) => {
-              const target = e.target as HTMLSelectElement;
-              this.llmConfig = { ...this.llmConfig, provider: target.value as 'openrouter' | 'openai' };
-            }}>
-              <option value="openrouter">OpenRouter</option>
-              <option value="openai">OpenAI</option>
-            </select>
-          </label>
-          <label>API Key
-            <input id="llm-key" type="password" .value=${this.llmConfig.apiKey} @input=${this._onApiKeyInput}>
-          </label>
-          <label>Model
-            <input id="llm-model" type="text" .value=${this.llmConfig.model} @input=${this._onModelInput}>
-          </label>
-          <label><input id="llm-summary" type="checkbox" .checked=${this.useLlmSummary} ?disabled=${!this.llmConfig.apiKey} @change=${this._onSummaryToggle}> Summarize text before reading</label>
-        </fieldset>
-        <fieldset>
-          <legend>Keyboard Shortcuts</legend>
-          <label>Play/Pause
-            <input id="kb-play" type="text" .value=${this.keybindings.playPause} @input=${(e: Event) => this._onKeybindingInput('playPause', e)}>
-          </label>
-          <label>Increase Speed
-            <input id="kb-inc" type="text" .value=${this.keybindings.increaseSpeed} @input=${(e: Event) => this._onKeybindingInput('increaseSpeed', e)}>
-          </label>
-          <label>Decrease Speed
-            <input id="kb-dec" type="text" .value=${this.keybindings.decreaseSpeed} @input=${(e: Event) => this._onKeybindingInput('decreaseSpeed', e)}>
-          </label>
-          <label>Rewind
-            <input id="kb-rew" type="text" .value=${this.keybindings.rewind} @input=${(e: Event) => this._onKeybindingInput('rewind', e)}>
-          </label>
-          <label>Fast Forward
-            <input id="kb-ff" type="text" .value=${this.keybindings.fastForward} @input=${(e: Event) => this._onKeybindingInput('fastForward', e)}>
-          </label>
-        </fieldset>
-        <fieldset>
-          <legend>Gestures</legend>
-          <label><input type="checkbox" .checked=${this.gestures.swipe} @change=${(e: Event) => this._onGestureToggle('swipe', e)}> Swipe Fast-Forward/Rewind</label>
-          <label><input type="checkbox" .checked=${this.gestures.taps} @change=${(e: Event) => this._onGestureToggle('taps', e)}> Tap Controls</label>
-          <label><input type="checkbox" .checked=${this.gestures.settingsSwipe} @change=${(e: Event) => this._onGestureToggle('settingsSwipe', e)}> Swipe Settings</label>
-        </fieldset>
+      <div class="dialog" role="dialog" aria-label="Settings">
+        <sp-close-button class="close-button" @click=${this._onClose} quiet></sp-close-button>
+        <sp-accordion allow-multiple>
+          <sp-accordion-item label="Content" open>
+            <sp-tabs
+              selected=${pasteActive ? 'paste' : 'url'}
+              @change=${(e: Event) => { this.mode = (e.target as any).selected as 'paste' | 'url'; }}>
+              <sp-tab value="paste">Paste Text</sp-tab>
+              <sp-tab value="url">From URL</sp-tab>
+            </sp-tabs>
+            ${pasteActive ? html`
+              <div>
+                <sp-field-label for="text-input">Text to Display:</sp-field-label>
+                <sp-textfield
+                  multiline
+                  id="text-input"
+                  .value=${this.text}
+                  @input=${this._onTextInput}
+                  ?readonly=${this.mode === 'url'}
+                  aria-readonly=${this.mode === 'url'}
+                ></sp-textfield>
+                <sp-field-label for="file-input">Import File:</sp-field-label>
+                <input
+                  id="file-input"
+                  type="file"
+                  accept=".txt,.html,.md,.markdown,.docx,.odt,text/plain,text/html,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.oasis.opendocument.text"
+                  @change=${this._onFileChange}
+                >
+              </div>
+            ` : html`
+              <div>
+                <sp-field-label for="url-input">URL to Load:</sp-field-label>
+                <sp-textfield id="url-input" type="url" .value=${this.url} @input=${this._onUrlInput}></sp-textfield>
+                <button class="load-url" @click=${this._loadUrl}>Load Content</button>
+              </div>
+            `}
+          </sp-accordion-item>
+          <sp-accordion-item label="Reading" open>
+            <label>Words Per Minute
+              <input
+                id="setting-wpm"
+                type="number"
+                min="100"
+                max="800"
+                .value=${String(this.wpm)}
+                @input=${this._onWpmInput}
+              >
+            </label>
+          </sp-accordion-item>
+          <sp-accordion-item label="LLM Summary">
+            <label>Provider
+              <select id="llm-provider" .value=${this.llmConfig.provider} @change=${(e: Event) => {
+                const target = e.target as HTMLSelectElement;
+                this.llmConfig = { ...this.llmConfig, provider: target.value as 'openrouter' | 'openai' };
+              }}>
+                <option value="openrouter">OpenRouter</option>
+                <option value="openai">OpenAI</option>
+              </select>
+            </label>
+            <label>API Key
+              <input id="llm-key" type="password" .value=${this.llmConfig.apiKey} @input=${this._onApiKeyInput}>
+            </label>
+            <label>Model
+              <input id="llm-model" type="text" .value=${this.llmConfig.model} @input=${this._onModelInput}>
+            </label>
+            <label><input id="llm-summary" type="checkbox" .checked=${this.useLlmSummary} ?disabled=${!this.llmConfig.apiKey} @change=${this._onSummaryToggle}> Summarize text before reading</label>
+          </sp-accordion-item>
+          <sp-accordion-item label="Shortcuts">
+            <label>Play/Pause
+              <input id="kb-play" type="text" .value=${this.keybindings.playPause} @input=${(e: Event) => this._onKeybindingInput('playPause', e)}>
+            </label>
+            <label>Increase Speed
+              <input id="kb-inc" type="text" .value=${this.keybindings.increaseSpeed} @input=${(e: Event) => this._onKeybindingInput('increaseSpeed', e)}>
+            </label>
+            <label>Decrease Speed
+              <input id="kb-dec" type="text" .value=${this.keybindings.decreaseSpeed} @input=${(e: Event) => this._onKeybindingInput('decreaseSpeed', e)}>
+            </label>
+            <label>Rewind
+              <input id="kb-rew" type="text" .value=${this.keybindings.rewind} @input=${(e: Event) => this._onKeybindingInput('rewind', e)}>
+            </label>
+            <label>Fast Forward
+              <input id="kb-ff" type="text" .value=${this.keybindings.fastForward} @input=${(e: Event) => this._onKeybindingInput('fastForward', e)}>
+            </label>
+          </sp-accordion-item>
+          <sp-accordion-item label="Gestures">
+            <label><input type="checkbox" .checked=${this.gestures.swipe} @change=${(e: Event) => this._onGestureToggle('swipe', e)}> Swipe Fast-Forward/Rewind</label>
+            <label><input type="checkbox" .checked=${this.gestures.taps} @change=${(e: Event) => this._onGestureToggle('taps', e)}> Tap Controls</label>
+            <label><input type="checkbox" .checked=${this.gestures.settingsSwipe} @change=${(e: Event) => this._onGestureToggle('settingsSwipe', e)}> Swipe Settings</label>
+          </sp-accordion-item>
+        </sp-accordion>
       </div>
     `;
   }

--- a/webcomponents/src/components/rsvp-settings.ts
+++ b/webcomponents/src/components/rsvp-settings.ts
@@ -47,6 +47,7 @@ export class RsvpSettings extends LitElement {
     taps: true,
     settingsSwipe: true,
   };
+  @property({ type: Number }) wpm = 300;
   @property({ type: Object }) llmConfig: LlmConfig = {
     provider: 'openrouter',
     apiKey: '',
@@ -259,6 +260,12 @@ export class RsvpSettings extends LitElement {
     }
   }
 
+  private _onWpmInput(e: Event) {
+    const target = e.target as HTMLInputElement;
+    this.wpm = parseInt(target.value, 10);
+    this.dispatchEvent(new CustomEvent('wpm-change', { detail: this.wpm }));
+  }
+
   private _onKeybindingInput(action: keyof Keybindings, e: Event) {
     const target = e.target as HTMLInputElement;
     const updated = { ...this.keybindings, [action]: target.value };
@@ -410,7 +417,29 @@ export class RsvpSettings extends LitElement {
           </div>
         `}
         <fieldset>
+          <legend>Reading Settings</legend>
+          <label>Words Per Minute
+            <input
+              id="setting-wpm"
+              type="number"
+              min="100"
+              max="800"
+              .value=${String(this.wpm)}
+              @input=${this._onWpmInput}
+            >
+          </label>
+        </fieldset>
+        <fieldset>
           <legend>LLM Summary</legend>
+          <label>Provider
+            <select id="llm-provider" .value=${this.llmConfig.provider} @change=${(e: Event) => {
+              const target = e.target as HTMLSelectElement;
+              this.llmConfig = { ...this.llmConfig, provider: target.value as 'openrouter' | 'openai' };
+            }}>
+              <option value="openrouter">OpenRouter</option>
+              <option value="openai">OpenAI</option>
+            </select>
+          </label>
           <label>API Key
             <input id="llm-key" type="password" .value=${this.llmConfig.apiKey} @input=${this._onApiKeyInput}>
           </label>


### PR DESCRIPTION
## Summary
- document settings pane options in component spec
- record decision to use an accordion layout for the pane
- describe settings interactions in feature form
- add initial WPM input and provider select to `rsvp-settings`
- wire `rsvp-player` to propagate WPM changes
- test new settings interactions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6862621e2e408331b236430a6992dcbe